### PR TITLE
refactor: update engine to use new updater api

### DIFF
--- a/shell/common/switches.cc
+++ b/shell/common/switches.cc
@@ -230,8 +230,6 @@ std::unique_ptr<fml::Mapping> GetSymbolMapping(
 Settings SettingsFromCommandLine(const fml::CommandLine& command_line) {
   Settings settings = {};
 
-  FML_LOG(ERROR) << "SettingsFromCommandLine";
-
   // Set executable name.
   if (command_line.has_argv0()) {
     settings.executable_name = command_line.argv0();

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -53,6 +53,7 @@ executable("flutter_shell_native_unittests") {
 }
 
 shared_library("flutter_shell_native") {
+  inputs = [ "android_exports.lst" ]
   output_name = "flutter"
   deps = [ ":flutter_shell_native_src" ]
   ldflags = [ "-Wl,--version-script=" + rebase_path("android_exports.lst") ]

--- a/shell/platform/android/android_exports.lst
+++ b/shell/platform/android/android_exports.lst
@@ -9,6 +9,12 @@
     JNI_OnLoad;
     _binary_icudtl_dat_start;
     _binary_icudtl_dat_size;
+    shorebird_init;
+    shorebird_active_path;
+    shorebird_active_version;
+    shorebird_free_string;
+    shorebird_check_for_update;
+    shorebird_update;
   local:
     *;
 };

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -77,6 +77,7 @@ const flutter::Settings& FlutterMain::GetSettings() const {
   return settings_;
 }
 
+// TODO: Move this out into a separate file?
 void ConfigureShorebird(std::string android_cache_path,
                         flutter::Settings& settings) {
   auto cache_dir =

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -91,7 +91,7 @@ void ConfigureShorebird(std::string android_cache_path,
   app_parameters.channel = "stable";
   app_parameters.client_id = "client_id";
   app_parameters.product_id = "com.example.product";
-  app_parameters.version = "1.0.0";
+  app_parameters.base_version = "1.0.0";
   app_parameters.update_url = NULL;  // default
 
   app_parameters.original_libapp_path =

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -77,6 +77,53 @@ const flutter::Settings& FlutterMain::GetSettings() const {
   return settings_;
 }
 
+void ConfigureShorebird(std::string android_cache_path,
+                        flutter::Settings& settings) {
+  auto cache_dir =
+      fml::paths::JoinPaths({android_cache_path, "shorebird_updater"});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(), {"shorebird_updater"},
+                       fml::FilePermission::kReadWrite);
+
+  AppParameters app_parameters;
+  // TODO: Read from AndroidManifest.xml
+  app_parameters.channel = "stable";
+  app_parameters.client_id = "client_id";
+  app_parameters.product_id = "com.example.product";
+  app_parameters.version = "1.0.0";
+  app_parameters.update_url = NULL;  // default
+
+  app_parameters.original_libapp_path =
+      settings.application_library_path[0].c_str();
+  // How do can we get the path to libflutter.so?
+  app_parameters.vm_path = "libflutter.so";
+
+  app_parameters.cache_dir = cache_dir.c_str();
+  shorebird_init(&app_parameters);
+
+  FML_LOG(INFO) << "Starting Shorebird update";
+  shorebird_update();
+
+  char* c_active_path = shorebird_active_path();
+  if (c_active_path != NULL) {
+    std::string active_path = c_active_path;
+    shorebird_free_string(c_active_path);
+    FML_LOG(INFO) << "Active path: " << active_path;
+
+    settings.application_library_path.clear();
+    settings.application_library_path.emplace_back(active_path);
+
+    char* c_version = shorebird_active_version();
+    if (c_version != NULL) {
+      std::string version = c_version;
+      shorebird_free_string(c_version);
+      FML_LOG(INFO) << "Active version: " << version;
+    }
+  } else {
+    FML_LOG(ERROR) << "Shorebird updater: no active path.";
+  }
+}
+
 void FlutterMain::Init(JNIEnv* env,
                        jclass clazz,
                        jobject context,
@@ -120,39 +167,11 @@ void FlutterMain::Init(JNIEnv* env,
       fml::jni::JavaStringToString(env, appStoragePath));
 
   auto android_cache_path = fml::jni::JavaStringToString(env, engineCachesPath);
-  auto cache_dir =
-      fml::paths::JoinPaths({android_cache_path, "shorebird_updater"});
   fml::paths::InitializeAndroidCachesPath(android_cache_path);
 
-  FML_LOG(ERROR) << "HACK IN HERE AND HOW";
-
-  fml::CreateDirectory(fml::paths::GetCachesDirectory(), {"shorebird_updater"},
-                       fml::FilePermission::kReadWrite);
-
-  std::string client_id = "client_id";
-
-  // void update(const char *client_id, const char *cache_dir);
-  update(client_id.c_str(), cache_dir.c_str());
-
-  // char *active_path(const char *client_id, const char *cache_dir);
-  char* c_active_path = active_path(client_id.c_str(), cache_dir.c_str());
-  if (c_active_path != NULL) {
-    std::string active_path = c_active_path;
-    free_string(c_active_path);
-    FML_LOG(ERROR) << "Active path: " << active_path;
-
-    settings.application_library_path.clear();
-    settings.application_library_path.emplace_back(active_path);
-
-    char* c_version = active_version(client_id.c_str(), cache_dir.c_str());
-    if (c_version != NULL) {
-      std::string version = c_version;
-      free_string(c_version);
-      FML_LOG(ERROR) << "Active version: " << version;
-    }
-  } else {
-    FML_LOG(ERROR) << "No active path";
-  }
+#if FLUTTER_RELEASE
+  ConfigureShorebird(android_cache_path, settings);
+#endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();
 

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -118,8 +118,6 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle) {
         }
       }
     }
-
-    NSLog("SHOREBIRD LOG");
   }
 
   // Checks to see if the flutter assets directory is already present.

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -53,9 +53,6 @@ _flutter_framework_headers_copy_dir =
 source_set("flutter_framework_source") {
   visibility = [ ":*" ]
 
-  include_dirs = [ "//flutter/updater" ]
-  libs = [ "//flutter/updater/macos/libupdater.a" ]
-
   sources = [
     "framework/Source/AccessibilityBridgeMac.h",
     "framework/Source/AccessibilityBridgeMac.mm",

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -5,8 +5,6 @@
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterDartProject.h"
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterDartProject_Internal.h"
 
-#include "updater.h"
-
 #include <vector>
 
 #include "flutter/shell/platform/common/engine_switches.h"
@@ -34,8 +32,6 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
     _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                               URLByAppendingPathComponent:@"App.framework"]];
   }
-  NSLog(@"Hack in HERE");
-
   auto fm = [NSFileManager defaultManager];
 
   // This should come from the application name.
@@ -78,36 +74,6 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
   [fm removeItemAtPath:dylibUrl.path error:&error];
   if (!success) {
     NSLog(@"Error: %@", error);
-  }
-
-  NSString* clientId = @"client_id";
-  // char *active_version(const char *client_id, const char *cache_dir);
-  update(clientId.UTF8String, cacheDir.UTF8String);
-
-  // char *active_path(const char *client_id, const char *cache_dir);
-  char* cActivePath = active_path(clientId.UTF8String, cacheDir.UTF8String);
-  if (cActivePath != NULL) {
-    NSString* activePath = [NSString stringWithUTF8String:cActivePath];
-    free_string(cActivePath);
-    NSLog(@"SUCCESS, got active_path: %@", activePath);
-    auto activeUrl = [NSURL fileURLWithPath:activePath];
-    success = [fm copyItemAtURL:activeUrl toURL:dylibUrl error:&error];
-    if (!success) {
-      NSLog(@"Error: %@", error);
-    } else {
-      NSLog(@"SUCCESS, booting from active_path: %@", activePath);
-      char* cVersion = active_version(clientId.UTF8String, cacheDir.UTF8String);
-      if (cVersion != NULL) {
-        NSString* version = [NSString stringWithUTF8String:cVersion];
-        free_string(cVersion);
-        NSLog(@"Running version: %@", version);
-      }
-
-      _dartBundle = [NSBundle bundleWithURL:appFrameworkUrl];
-    }
-
-  } else {
-    NSLog(@"FAIL, got active_path: %@", @"NULL");
   }
 
   if (!_dartBundle.isLoaded) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterDartProject.mm
@@ -32,49 +32,6 @@ static NSString* const kAppBundleIdentifier = @"io.flutter.flutter.app";
     _dartBundle = [NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                               URLByAppendingPathComponent:@"App.framework"]];
   }
-  auto fm = [NSFileManager defaultManager];
-
-  // This should come from the application name.
-  auto path = @"~/Library/Application Support/flutter_updater";
-  auto expandedPath = [path stringByExpandingTildeInPath];
-  auto cacheDir = [expandedPath stringByAppendingPathComponent:@"cache"];
-  NSLog(@"Cache dir: %@", cacheDir);
-  NSError* error = nil;
-  BOOL success = [fm createDirectoryAtPath:cacheDir
-               withIntermediateDirectories:YES
-                                attributes:nil
-                                     error:&error];
-  if (!success) {
-    NSLog(@"Error: %@", error);
-  }
-
-  auto bootDir = [expandedPath stringByAppendingPathComponent:@"boot"];
-  success = [fm createDirectoryAtPath:bootDir
-          withIntermediateDirectories:YES
-                           attributes:nil
-                                error:&error];
-  if (!success) {
-    NSLog(@"Error: %@", error);
-  }
-
-  auto bootDirUrl = [NSURL fileURLWithPath:bootDir];
-  auto appFrameworkUrl = [bootDirUrl URLByAppendingPathComponent:@"App.framework"];
-
-  [fm removeItemAtPath:appFrameworkUrl.path error:&error];
-  if (!success) {
-    NSLog(@"Error: %@", error);
-  }
-
-  success = [fm copyItemAtURL:_dartBundle.bundleURL toURL:appFrameworkUrl error:&error];
-  if (!success) {
-    NSLog(@"Error: %@", error);
-  }
-
-  auto dylibUrl = [appFrameworkUrl URLByAppendingPathComponent:@"Versions/Current/App"];
-  [fm removeItemAtPath:dylibUrl.path error:&error];
-  if (!success) {
-    NSLog(@"Error: %@", error);
-  }
 
   if (!_dartBundle.isLoaded) {
     [_dartBundle load];


### PR DESCRIPTION
I also took the opportunity to consolidate all the Shorebird code into a single function and disable it in debug builds.

This still doesn't pass quite all the data the updater expects, but at least it's on the new API and we can do that in a second pass.

There are also changes here about trying to expose the shorebird updater symbols from libflutter.so so that Flutter apps (via the "dart_bindings" package) can use dart:ffi to call into the updater library as well.