### PR TITLE
Call report_failed_launch when VM fails to initialize

### DIFF
--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -140,6 +140,8 @@ source_set("common") {
     "//third_party/skia",
   ]
 
+  include_dirs = [ "//flutter/updater" ]
+
   if (impeller_supports_rendering) {
     sources += [
       "snapshot_controller_impeller.cc",

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -33,6 +33,8 @@
 #include "third_party/skia/include/utils/SkBase64.h"
 #include "third_party/tonic/common/log.h"
 
+#include "updater.h"
+
 namespace flutter {
 
 constexpr char kSkiaChannel[] = "flutter/skia";
@@ -137,6 +139,9 @@ std::unique_ptr<Shell> Shell::Create(
   auto isolate_snapshot = DartSnapshot::IsolateSnapshotFromSettings(settings);
   auto vm = DartVMRef::Create(settings, vm_snapshot, isolate_snapshot);
   FML_CHECK(vm) << "Must be able to initialize the VM.";
+  if (!vm) {
+    shorebird_report_failed_launch();
+  }
 
   // If the settings did not specify an `isolate_snapshot`, fall back to the
   // one the VM was launched with.


### PR DESCRIPTION
This will cause the updater to not recommend that patch again.