### PR TITLE
Teach our fork of the engine to build on Android arm32

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -140,8 +140,12 @@ source_set("flutter_shell_native_src") {
     "android",
     "EGL",
     "GLESv2",
-    "//flutter/updater/android_aarch64/libupdater.a",
   ]
+  if (target_cpu == "arm") {
+    libs += [ "//flutter/updater/android_arm/libupdater.a" ]
+  } else if (target_cpu == "arm64") {
+    libs += [ "//flutter/updater/android_aarch64/libupdater.a" ]
+  }
 }
 
 action("gen_android_build_config_java") {


### PR DESCRIPTION
This required conditionally linking against separate builds of libupdater.a as well as providing a stub for getauxval.

If we find a way to move off of using ring (via rust-tls, via reqwests) we could get rid of this.  More likely Flutter will just move to a newer version of SDK/NDK:
https://github.com/flutter/flutter/issues/82000