### PR TITLE
feat: Use Android versionCode for patch checks

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -21,7 +21,7 @@ vars = {
   'skia_revision': '7e1844439eaa3eb24d00c6314ddc81ca532fdd1b',
 
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
-  'updater_rev': 'bc19f5df79005d65073debdc736f17ca6d827f89',
+  'updater_rev': '1281624ccf44a1dc2c2b362f7bb65f06ce0c56f3',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -97,7 +97,8 @@ extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
 void ConfigureShorebird(std::string android_cache_path,
                         flutter::Settings& settings,
                         std::string shorebirdYaml,
-                        std::string version) {
+                        std::string version,
+                        long version_code) {
   auto cache_dir =
       fml::paths::JoinPaths({android_cache_path, "shorebird_updater"});
 
@@ -127,7 +128,8 @@ void ConfigureShorebird(std::string android_cache_path,
   }
 
   FML_LOG(INFO) << "Starting Shorebird update";
-  shorebird_update();
+  FML_LOG(INFO) << "Version" << version;
+  FML_LOG(INFO) << "Version Code" << version_code;
 
   char* c_active_path = shorebird_active_path();
   if (c_active_path != NULL) {
@@ -159,6 +161,7 @@ void FlutterMain::Init(JNIEnv* env,
                        jstring engineCachesPath,
                        jstring shorebirdYaml,
                        jstring version,
+                       jlong versionCode,
                        jlong initTimeMillis) {
   std::vector<std::string> args;
   args.push_back("flutter");
@@ -200,8 +203,9 @@ void FlutterMain::Init(JNIEnv* env,
 #if FLUTTER_RELEASE
   std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
   std::string version_string = fml::jni::JavaStringToString(env, version);
+  long version_code = versionCode;
   ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
-                     version_string);
+                     version_string, version_code);
 #endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();
@@ -291,7 +295,7 @@ bool FlutterMain::Register(JNIEnv* env) {
           .name = "nativeInit",
           .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
                        "lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/"
-                       "lang/String;Ljava/lang/String;J)V",
+                       "lang/String;Ljava/lang/String;J;J)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },
       {

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -108,7 +108,8 @@ void ConfigureShorebird(std::string android_cache_path,
   // Using a block to make AppParameters lifetime explicit.
   {
     AppParameters app_parameters;
-    app_parameters.release_version = version.c_str();
+    app_parameters.version_name = version.c_str();
+    app_parameters.version_code = version_code;
     app_parameters.cache_dir = cache_dir.c_str();
 
     // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
@@ -120,8 +121,6 @@ void ConfigureShorebird(std::string android_cache_path,
 
     app_parameters.original_libapp_paths = c_paths.data();
     app_parameters.original_libapp_paths_size = c_paths.size();
-
-    app_parameters.vm_path = "libflutter.so";  // Unused.
 
     // shorebird_init copies from app_parameters and shorebirdYaml.
     shorebird_init(&app_parameters, shorebirdYaml.c_str());
@@ -297,7 +296,7 @@ bool FlutterMain::Register(JNIEnv* env) {
           .name = "nativeInit",
           .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
                        "lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/"
-                       "lang/String;Ljava/lang/String;J;J)V",
+                       "lang/String;Ljava/lang/String;JJ)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },
       {

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -131,6 +131,8 @@ void ConfigureShorebird(std::string android_cache_path,
   FML_LOG(INFO) << "Version" << version;
   FML_LOG(INFO) << "Version Code" << version_code;
 
+  shorebird_update();
+
   char* c_active_path = shorebird_active_path();
   if (c_active_path != NULL) {
     std::string active_path = c_active_path;

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -38,6 +38,7 @@ class FlutterMain {
                    jstring engineCachesPath,
                    jstring shorebirdYaml,
                    jstring version,
+                   jlong versionCode,
                    jlong initTimeMillis);
 
   void SetupObservatoryUriCallback(JNIEnv* env);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -5,8 +5,8 @@
 package io.flutter.embedding.engine;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -209,7 +209,8 @@ public class FlutterJNI {
       // Should this be versionName or getLongVersionCode()?
       // versionName is human readable, but getLongVersionCode() is a
       // monotonically increasing number.
-      PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      PackageInfo packageInfo =
+          context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
       version = packageInfo.versionName;
       versionCode = packageInfo.getLongVersionCode();
     } catch (PackageManager.NameNotFoundException e) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -6,6 +6,7 @@ package io.flutter.embedding.engine;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageInfo;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -176,6 +177,7 @@ public class FlutterJNI {
       @NonNull String engineCachesPath,
       @Nullable String shorebirdYaml,
       @Nullable String version,
+      long versionCode,
       long initTimeMillis);
 
   /**
@@ -202,11 +204,14 @@ public class FlutterJNI {
     }
 
     String version = null;
+    long versionCode = 1;
     try {
       // Should this be versionName or getLongVersionCode()?
       // versionName is human readable, but getLongVersionCode() is a
       // monotonically increasing number.
-      version = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
+      PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      version = packageInfo.versionName;
+      versionCode = packageInfo.getLongVersionCode();
     } catch (PackageManager.NameNotFoundException e) {
       Log.e(TAG, "Failed to read app version.  Shorebird updater can't run.", e);
     }
@@ -233,6 +238,7 @@ public class FlutterJNI {
         engineCachesPath,
         shorebirdYaml,
         version,
+        versionCode,
         initTimeMillis);
     FlutterJNI.initCalled = true;
   }


### PR DESCRIPTION
Plumb version_code through to the updater.

If we didn't do this, it's possible for someone to release 1.0.0+1 and 1.0.0+2 and us treat them the same.