### PR TITLE
chore: better logging when shorebird.yaml is missing

### DIFF
--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -204,17 +204,11 @@ void FlutterMain::Init(JNIEnv* env,
   fml::paths::InitializeAndroidCachesPath(android_cache_path);
 
 #if FLUTTER_RELEASE
-  if (shorebirdYaml) {
-    std::string shorebird_yaml =
-        fml::jni::JavaStringToString(env, shorebirdYaml);
-    std::string version_string = fml::jni::JavaStringToString(env, version);
-    long version_code = versionCode;
-    ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
-                       version_string, version_code);
-  } else {
-    __android_log_print(ANDROID_LOG_ERROR, "Flutter",
-                        "No Shorebird.yaml provided");
-  }
+  std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
+  std::string version_string = fml::jni::JavaStringToString(env, version);
+  long version_code = versionCode;
+  ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
+                     version_string, version_code);
 #endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -204,11 +204,16 @@ void FlutterMain::Init(JNIEnv* env,
   fml::paths::InitializeAndroidCachesPath(android_cache_path);
 
 #if FLUTTER_RELEASE
-  std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
-  std::string version_string = fml::jni::JavaStringToString(env, version);
-  long version_code = versionCode;
-  ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
-                     version_string, version_code);
+  if (shorebirdYaml) {
+    std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
+    std::string version_string = fml::jni::JavaStringToString(env, version);
+    long version_code = versionCode;
+    ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
+                      version_string, version_code);
+  } else {
+    __android_log_print(ANDROID_LOG_ERROR,
+        "Flutter", "No Shorebird.yaml provided");
+  }
 #endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -205,14 +205,15 @@ void FlutterMain::Init(JNIEnv* env,
 
 #if FLUTTER_RELEASE
   if (shorebirdYaml) {
-    std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
+    std::string shorebird_yaml =
+        fml::jni::JavaStringToString(env, shorebirdYaml);
     std::string version_string = fml::jni::JavaStringToString(env, version);
     long version_code = versionCode;
     ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
-                      version_string, version_code);
+                       version_string, version_code);
   } else {
-    __android_log_print(ANDROID_LOG_ERROR,
-        "Flutter", "No Shorebird.yaml provided");
+    __android_log_print(ANDROID_LOG_ERROR, "Flutter",
+                        "No Shorebird.yaml provided");
   }
 #endif
 

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -5,8 +5,8 @@
 package io.flutter.embedding.engine;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -206,7 +206,8 @@ public class FlutterJNI {
     String version = null;
     long versionCode = 0;
     try {
-      PackageInfo packageInfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      PackageInfo packageInfo =
+          context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
       version = packageInfo.versionName;
       versionCode = packageInfo.getLongVersionCode();
     } catch (PackageManager.NameNotFoundException e) {

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -225,6 +225,7 @@ public class FlutterJNI {
       Log.w(TAG, "shorebird.yaml: " + shorebirdYaml);
     } catch (IOException e) {
       Log.e(TAG, "Failed to load shorebird.yaml", e);
+      Log.e(TAG, "Did you remember to include shorebird.yaml in your pubspec.yaml's assets?");
     }
 
     FlutterJNI.nativeInit(


### PR DESCRIPTION
Updated formatting and added a fix hint for a missing `shorebird.yaml` in `flutter_main.cc`.

Related to https://github.com/shorebirdtech/shorebird/issues/413
