### PR TITLE
fix: guard `getLongVersionCode` API in FlutterJNI

### DIFF
--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -209,7 +209,11 @@ public class FlutterJNI {
       PackageInfo packageInfo =
           context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
       version = packageInfo.versionName;
-      versionCode = packageInfo.getLongVersionCode();
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        versionCode = packageInfo.getLongVersionCode();
+      } else {
+        versionCode = packageInfo.versionCode;
+      }
     } catch (PackageManager.NameNotFoundException e) {
       Log.e(TAG, "Failed to read app version.  Shorebird updater can't run.", e);
     }


### PR DESCRIPTION
fix: guard `getLongVersionCode` API in FlutterJNI