### PR TITLE
Hacks for iOS demo

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,8 +20,10 @@ vars = {
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
   'skia_revision': 'ad8fa4a38668a9671d5aa24faa92cb4f53cf15f1',
 
+  'dart_sdk_revision': '96ac26bd7342b38251866bb669128f432fb14fda',
+  'dart_sdk_git': 'https://github.com/shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
-  'updater_rev': '11d8c2280539f08d55c5bd0b019adbd5cfa373dc',
+  'updater_rev': '4d2ec2e148f5205cf018f0eb854113d9d8b380b3',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
@@ -325,7 +327,7 @@ deps = {
    Var('fuchsia_git') + '/protobuf-gn' + '@' + Var('dart_protobuf_gn_rev'),
 
   'src/third_party/dart':
-   Var('dart_git') + '/sdk.git' + '@' + Var('dart_revision'),
+   Var('dart_sdk_git') + '@' + Var('dart_sdk_revision'),
 
   # WARNING: Unused Dart dependencies in the list below till "WARNING:" marker are removed automatically - see create_updated_flutter_deps.py.
 

--- a/shell/common/shorebird.cc
+++ b/shell/common/shorebird.cc
@@ -1,0 +1,103 @@
+
+#include "flutter/shell/common/shorebird.h"
+
+#include <optional>
+#include <vector>
+
+#include "flutter/fml/command_line.h"
+#include "flutter/fml/file.h"
+#include "flutter/fml/macros.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/native_library.h"
+#include "flutter/fml/paths.h"
+#include "flutter/fml/size.h"
+#include "flutter/lib/ui/plugins/callback_cache.h"
+#include "flutter/runtime/dart_vm.h"
+#include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/switches.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+#include "third_party/skia/include/core/SkFontMgr.h"
+
+#include "third_party/updater/library/include/updater.h"
+
+// Namespaced to avoid Google style warnings.
+namespace flutter {
+
+// Old Android versions (e.g. the v16 ndk Flutter uses) don't always include a
+// getauxval symbol, but the Rust ring crate assumes it exists:
+// https://github.com/briansmith/ring/blob/fa25bf3a7403c9fe6458cb87bd8427be41225ca2/src/cpu/arm.rs#L22
+// It uses it to determine if the CPU supports AES instructions.
+// Making this a weak symbol allows the linker to use a real version instead
+// if it can find one.
+// BoringSSL just reads from procfs instead, which is what we would do if
+// we needed to implement this ourselves.  Implementation looks straightforward:
+// https://lwn.net/Articles/519085/
+// https://github.com/google/boringssl/blob/6ab4f0ae7f2db96d240eb61a5a8b4724e5a09b2f/crypto/cpu_arm_linux.c
+#if defined(__ANDROID__) && defined(__arm__)
+extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
+  return 0;
+}
+#endif
+
+void ConfigureShorebird(std::string cache_path,
+                        flutter::Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        int64_t version_code) {
+  auto cache_dir =
+      fml::paths::JoinPaths({std::move(cache_path), "shorebird_updater"});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(), {"shorebird_updater"},
+                       fml::FilePermission::kReadWrite);
+
+  // Using a block to make AppParameters lifetime explicit.
+  {
+    AppParameters app_parameters;
+    // Combine version and version_code into a single string.
+    // We could also pass these separately through to the updater if needed.
+    auto release_version = version + "+" + std::to_string(version_code);
+    app_parameters.release_version = release_version.c_str();
+    app_parameters.cache_dir = cache_dir.c_str();
+
+    // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
+    std::vector<const char*> c_paths{};
+    for (const auto& string : settings.application_library_path) {
+      c_paths.push_back(string.c_str());
+    }
+    // Do not modify application_library_path or c_strings will invalidate.
+
+    app_parameters.original_libapp_paths = c_paths.data();
+    app_parameters.original_libapp_paths_size = c_paths.size();
+
+    // shorebird_init copies from app_parameters and shorebirdYaml.
+    shorebird_init(&app_parameters, shorebird_yaml.c_str());
+  }
+
+  char* c_active_path = shorebird_next_boot_patch_path();
+  if (c_active_path != NULL) {
+    std::string active_path = c_active_path;
+    shorebird_free_string(c_active_path);
+    FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
+    char* c_patch_number = shorebird_next_boot_patch_number();
+    if (c_patch_number != NULL) {
+      std::string patch_number = c_patch_number;
+      shorebird_free_string(c_patch_number);
+      FML_LOG(INFO) << "Shorebird updater: active patch number: "
+                    << patch_number;
+    }
+
+    settings.application_library_path.clear();
+    settings.application_library_path.emplace_back(active_path);
+    // Once start_update_thread is called, the next_boot_patch* functions may
+    // change their return values if the shorebird_report_launch_failed
+    // function is called.
+    shorebird_report_launch_start();
+  } else {
+    FML_LOG(INFO) << "Shorebird updater: no active patch.";
+  }
+
+  FML_LOG(INFO) << "Starting Shorebird update";
+  shorebird_start_update_thread();
+}
+
+}  // namespace flutter

--- a/shell/common/shorebird.h
+++ b/shell/common/shorebird.h
@@ -1,0 +1,16 @@
+#ifndef SHELL_COMMON_SHOREBIRD_H_
+#define SHELL_COMMON_SHOREBIRD_H_
+
+#include "flutter/common/settings.h"
+
+namespace flutter {
+
+void ConfigureShorebird(std::string cache_path,
+                        flutter::Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        int64_t version_code);
+
+}  // namespace flutter
+
+#endif  // SHELL_COMMON_SHOREBIRD_H_

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -66,6 +66,8 @@ source_set("flutter_shell_native_src") {
 
   sources = [
     "$root_build_dir/flutter_icu/icudtl.o",
+    "../../common/shorebird.cc",
+    "../../common/shorebird.h",
     "android_choreographer.cc",
     "android_choreographer.h",
     "android_context_gl_impeller.cc",

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -23,6 +23,7 @@
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "third_party/skia/include/core/SkFontMgr.h"
@@ -75,84 +76,6 @@ FlutterMain& FlutterMain::Get() {
 
 const flutter::Settings& FlutterMain::GetSettings() const {
   return settings_;
-}
-
-// Old Android versions (e.g. the v16 ndk Flutter uses) don't always include a
-// getauxval symbol, but the Rust ring crate assumes it exists:
-// https://github.com/briansmith/ring/blob/fa25bf3a7403c9fe6458cb87bd8427be41225ca2/src/cpu/arm.rs#L22
-// It uses it to determine if the CPU supports AES instructions.
-// Making this a weak symbol allows the linker to use a real version instead
-// if it can find one.
-// BoringSSL just reads from procfs instead, which is what we would do if
-// we needed to implement this ourselves.  Implementation looks straightforward:
-// https://lwn.net/Articles/519085/
-// https://github.com/google/boringssl/blob/6ab4f0ae7f2db96d240eb61a5a8b4724e5a09b2f/crypto/cpu_arm_linux.c
-#if defined(__ANDROID__) && defined(__arm__)
-extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
-  return 0;
-}
-#endif
-
-// TODO: Move this out into a separate file?
-void ConfigureShorebird(std::string android_cache_path,
-                        flutter::Settings& settings,
-                        std::string shorebirdYaml,
-                        std::string version,
-                        long version_code) {
-  auto cache_dir =
-      fml::paths::JoinPaths({android_cache_path, "shorebird_updater"});
-
-  fml::CreateDirectory(fml::paths::GetCachesDirectory(), {"shorebird_updater"},
-                       fml::FilePermission::kReadWrite);
-
-  // Using a block to make AppParameters lifetime explicit.
-  {
-    AppParameters app_parameters;
-    // Combine version and version_code into a single string.
-    // We could also pass these separately through to the updater if needed.
-    auto release_version = version + "+" + std::to_string(version_code);
-    app_parameters.release_version = release_version.c_str();
-    app_parameters.cache_dir = cache_dir.c_str();
-
-    // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
-    std::vector<const char*> c_paths{};
-    for (const auto& string : settings.application_library_path) {
-      c_paths.push_back(string.c_str());
-    }
-    // Do not modify application_library_path or c_strings will invalidate.
-
-    app_parameters.original_libapp_paths = c_paths.data();
-    app_parameters.original_libapp_paths_size = c_paths.size();
-
-    // shorebird_init copies from app_parameters and shorebirdYaml.
-    shorebird_init(&app_parameters, shorebirdYaml.c_str());
-  }
-
-  char* c_active_path = shorebird_next_boot_patch_path();
-  if (c_active_path != NULL) {
-    std::string active_path = c_active_path;
-    shorebird_free_string(c_active_path);
-    FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
-    char* c_patch_number = shorebird_next_boot_patch_number();
-    if (c_patch_number != NULL) {
-      std::string patch_number = c_patch_number;
-      shorebird_free_string(c_patch_number);
-      FML_LOG(INFO) << "Shorebird updater: active patch number: "
-                    << patch_number;
-    }
-
-    settings.application_library_path.clear();
-    settings.application_library_path.emplace_back(active_path);
-    // Once start_update_thread is called, the next_boot_patch* functions may
-    // change their return values if the shorebird_report_launch_failed
-    // function is called.
-    shorebird_report_launch_start();
-  } else {
-    FML_LOG(INFO) << "Shorebird updater: no active patch.";
-  }
-
-  FML_LOG(INFO) << "Starting Shorebird update";
-  shorebird_start_update_thread();
 }
 
 void FlutterMain::Init(JNIEnv* env,

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -71,6 +71,8 @@ source_set("flutter_framework_source") {
   deps = []
 
   sources = [
+    "../../../common/shorebird.cc",
+    "../../../common/shorebird.h",
     "framework/Source/FlutterAppDelegate.mm",
     "framework/Source/FlutterBinaryMessengerRelay.mm",
     "framework/Source/FlutterCallbackCache.mm",
@@ -187,6 +189,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
     "//flutter/shell/profiling:profiling",
     "//flutter/third_party/spring_animation",
+    "//third_party/dart/runtime/bin:elf_loader",
     "//third_party/skia",
   ]
 
@@ -194,6 +197,16 @@ source_set("flutter_framework_source") {
     ":ios_gpu_configuration_config",
     "//flutter:config",
   ]
+
+  if (target_cpu == "arm64") {
+    libs =
+        [ "//third_party/updater/target/aarch64-apple-ios/debug/libupdater.a" ]
+  } else if (target_cpu == "x64") {
+    libs =
+        [ "//third_party/updater/target/x86_64-apple-ios/debug/libupdater.a" ]
+  } else {
+    assert(false, "Unsupported target_cpu")
+  }
 
   frameworks = [
     "AudioToolbox.framework",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -15,12 +15,16 @@
 #include "flutter/common/task_runners.h"
 #include "flutter/fml/mapping.h"
 #include "flutter/fml/message_loop.h"
+#include "flutter/fml/paths.h"
 #include "flutter/fml/platform/darwin/scoped_nsobject.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
 #import "flutter/shell/platform/darwin/ios/framework/Headers/FlutterViewController.h"
+
+#include "third_party/updater/library/include/updater.h"
 
 extern "C" {
 #if FLUTTER_RUNTIME_MODE == FLUTTER_RUNTIME_MODE_DEBUG
@@ -86,10 +90,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   }
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
+    NSLog(@"SANITY CHECK: Running precompiled code.");
     if (hasExplicitBundle) {
       NSString* executablePath = bundle.executablePath;
       if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
         settings.application_library_path.push_back(executablePath.UTF8String);
+        NSLog(@"Using precompiled library from %@", executablePath);
       }
     }
 
@@ -101,6 +107,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         NSString* executablePath = [NSBundle bundleWithPath:libraryPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using library from %@", libraryPath);
         }
       }
     }
@@ -115,6 +122,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
             [NSBundle bundleWithPath:applicationFrameworkPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using App.framework from %@", applicationFrameworkPath);
         }
       }
     }
@@ -148,6 +156,39 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         }
       }
     }
+  }
+
+  NSString* assetsPath = [NSString stringWithUTF8String:settings.assets_path.c_str()];
+  NSLog(@"ASSET PATH %@", assetsPath);
+
+  std::string cache_path = fml::paths::JoinPaths({getenv("HOME"), "Library/Caches/shorebird"});
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* appVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  // HACK: Pull out the first component of the bundle version as an int:
+  // 1.2.3 -> 1
+  int version_code = [appBuildNumber intValue];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  if (shorebirdYamlContents != nil) {
+    flutter::ConfigureShorebird(cache_path, settings, shorebirdYamlContents.UTF8String,
+                                appVersion.UTF8String, version_code);
+  } else {
+    NSLog(@"Failed to find shorebird.yaml, not starting updater.");
+  }
+
+  // Hack, just replacing the snapshot for a demo.
+  NSURL* appElfLib = [NSURL URLWithString:@"out.aot"
+                            relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  if ([[NSFileManager defaultManager] fileExistsAtPath:appElfLib.path]) {
+    settings.application_library_path.clear();
+    settings.application_library_path.push_back(appElfLib.path.UTF8String);
+    NSLog(@"Replaced snapshot with: %@", appElfLib.path);
+  } else {
+    NSLog(@"Failed to find snapshot: %@", appElfLib.path);
+    abort();
   }
 
   // Domain network configuration

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -32,6 +32,8 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
+#import <third_party/dart/runtime/vm/cpu.h>
+
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
@@ -229,6 +231,8 @@ typedef struct MouseState {
   if (!project) {
     project = [[[FlutterDartProject alloc] init] autorelease];
   }
+  FML_LOG(INFO) << "CPU::Id(): " << dart::CPU::Id();
+
   FlutterView.forceSoftwareRendering = project.settings.enable_software_rendering;
   _weakFactory = std::make_unique<fml::WeakPtrFactory<FlutterViewController>>(self);
   auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]


### PR DESCRIPTION
I've verified that this builds with 3.10.2.  I rebased onto shorebird/main before landing.

These are just the hacks needed for my current iOS demo.  This will still need more cleanup once the CLI/server sides are working.

Changes included:
* Split dart_sdk_revision and dart_sdk_git from dart_revision and dart_git since those affect other repos as well.
* Added a hacky path for loading symbols from an elf file on iOS.  Will need modification for production.
* Moved the ConfigureShorebird logic out into its own shorebird.cc file and shared between iOS and Android
* Added some hacks into iOS startup to use my hacky elf loader for loading in the dart snapshot instead of the default pathway.
* Turned on dart_force_simulator for iOS.