### PR TITLE
fix: don't attempt to init shorebird if we aren't running in a Flutter app

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'dart_sdk_revision': '69fdf1867dc65697420febd94d061e6ab90e5d7c',
   'dart_sdk_git': 'https://github.com/shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
-  'updater_rev': 'bce15087879a06d7e7f4ce37c1a54dd13bc4b8b1',
+  'updater_rev': 'c627ad79a185941f44100292fcf04cbabd4c11d0',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/shell/common/shorebird.cc
+++ b/shell/common/shorebird.cc
@@ -46,8 +46,8 @@ extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
 /// Because we pass the absolute path to our Rust code, that path is the one we
 /// care about.
 std::string AppLibraryFilename(std::vector<std::string> libapp_paths) {
-// FIXME: resolve the full path from the first item in this list (the filename
-// itself) and pass that to Rust. See updater.rs for more details.
+  // FIXME: resolve the full path from the first item in this list (the filename
+  // itself) and pass that to Rust. See updater.rs for more details.
   std::filesystem::path path(libapp_paths.back());
   return path.filename().string();
 }

--- a/shell/common/shorebird.cc
+++ b/shell/common/shorebird.cc
@@ -84,7 +84,7 @@ void ConfigureShorebird(std::string cache_path,
         << app_library_filename << ").";
     return;
   }
-  
+
   auto cache_dir =
       fml::paths::JoinPaths({std::move(cache_path), "shorebird_updater"});
 

--- a/shell/common/shorebird.cc
+++ b/shell/common/shorebird.cc
@@ -1,6 +1,7 @@
 
 #include "flutter/shell/common/shorebird.h"
 
+#include <filesystem>
 #include <optional>
 #include <vector>
 
@@ -39,6 +40,28 @@ extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
 }
 #endif
 
+/// Checks whether the last item in the list of application library paths has a
+/// filename that matches what we expect to see for a Flutter app on the current
+/// platform.
+///
+/// On Android, this is "libapp.so".
+/// On iOS, this is "App".
+bool IsRunningApp(std::vector<std::string> libapp_paths) {
+  std::filesystem::path path(libapp_paths.back());
+  std::string filename = path.filename().string();
+
+// Check for the filename we expect on the current platform.
+#if defined(__ANDROID__)
+  return filename == "libapp.so";
+#elif defined(__APPLE__)
+  return filename == "App";
+#endif
+
+  // If we aren't on Android or iOS, we're in an unfamiliar environment and
+  // shouldn't assume we're running a Flutter app.
+  return false;
+}
+
 void ConfigureShorebird(std::string cache_path,
                         flutter::Settings& settings,
                         const std::string& shorebird_yaml,
@@ -66,8 +89,24 @@ void ConfigureShorebird(std::string cache_path,
     }
     // Do not modify application_library_path or c_strings will invalidate.
 
+    // original_libapp_paths is a set of fallback paths to libapp.so.
+    // The first item in original_libapp_paths will be "libapp.so".
+    // This fails on some old versions of Android, and will fall back to the
+    // second path, which is the absolute path to the libapp.so file.
+    // FIXME: resolve the full path from "libapp.so" and pass that to Rust.
+    // See updater.rs for more details.
     app_parameters.original_libapp_paths = c_paths.data();
     app_parameters.original_libapp_paths_size = c_paths.size();
+
+    // If we don't believe that we're running a full Flutter app, warn the user
+    // and don't try to initialize Shorebird.
+    if (!IsRunningApp(settings.application_library_path)) {
+      FML_LOG(WARNING)
+          << "Shorebird updater: application library detected is not "
+             "libapp.so, not running shorebird_init (detected "
+          << settings.application_library_path.front() << ").";
+      return;
+    }
 
     // shorebird_init copies from app_parameters and shorebirdYaml.
     shorebird_init(&app_parameters, shorebird_yaml.c_str());


### PR DESCRIPTION
This also updates the Updater revision in DEPS to handle the change of `shorebird_next_boot_patch_number`'s return type.