### PR TITLE
fix: export `shorebird_next_boot_patch_number` and `shorebird_current_boot_patch_number`

### DIFF
--- a/shell/platform/android/android_exports.lst
+++ b/shell/platform/android/android_exports.lst
@@ -15,6 +15,8 @@
     shorebird_free_string;
     shorebird_check_for_update;
     shorebird_update;
+    shorebird_next_boot_patch_number;
+    shorebird_current_boot_patch_number;
   local:
     *;
 };


### PR DESCRIPTION
fix: export `shorebird_next_boot_patch_number` and `shorebird_current_boot_patch_number`