### PR TITLE
fix: report successful launches

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -146,6 +146,8 @@ std::unique_ptr<Shell> Shell::Create(
 #if FML_OS_ANDROID || FML_OS_IOS
   if (!vm) {
     shorebird_report_launch_failure();
+  } else {
+    shorebird_report_launch_success();
   }
 #endif
   FML_CHECK(vm) << "Must be able to initialize the VM.";


### PR DESCRIPTION
We may eventually want to be more sophisticated about this, but we aren't currently reporting successful launches anywhere that I can find.