### PR TITLE
bump updater rev

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'dart_sdk_revision': '8ec6d70245145f4a9530b9cebf76607124fd8b6c',
   'dart_sdk_git': 'git@github.com:shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
-  'updater_rev': '99f3005ff433f7b2555dd6655dd3a66d855ea6a3',
+  'updater_rev': '7417429d918673da0a4736c9b863811ca9986f67',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.


### PR DESCRIPTION
Bumps the updater revision to point to https://github.com/shorebirdtech/updater/commit/7417429d918673da0a4736c9b863811ca9986f67, which adds a friendlier error message in case of no internet connection.