### PR TITLE
fix: avoid executable memory when USING_SIMULATOR

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@ vars = {
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
   'skia_revision': 'd58324bf653df78837bcf46685ca6141d86540ba',
 
-  'dart_sdk_revision': 'fb5e20e227cd53dc8d43b0039f2748752ce8bdf0',
+  'dart_sdk_revision': 'e0e09bdc981beeb88f798bc00536070466c5234f',
   'dart_sdk_git': 'git@github.com:shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
   'updater_rev': '53072a91281922025155477ea2ba009f690c8eed',

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -70,7 +70,8 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
       const char* error = nullptr;
       leaked_elf = Dart_LoadELF(native_library_path.back().c_str(), 0, &error,
                                 &vm_snapshot_data, &vm_snapshot_instrs,
-                                &vm_isolate_data, &vm_isolate_instrs);
+                                &vm_isolate_data, &vm_isolate_instrs,
+                                /* load as read-only, not rx */ true);
       if (leaked_elf != nullptr) {
         FML_LOG(INFO) << "Loaded ELF";
       } else {


### PR DESCRIPTION
Fixes https://github.com/shorebirdtech/shorebird/issues/1183.

Some versions of iOS were sometimes killing apps using Shorebird due to codesigning.  We were loading the Dart snapshot (unsigned) as executable (since Dart normally does) even though we never execute code from it on iOS.

This updates to use a version of or Dart fork which allows you to make Dart not mark those pages as executable, which seems to fix the issue.