### PR TITLE
fix: use appStoragePath instead of cachesPath, as cachesPath is cleared with every release

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -23,7 +23,7 @@ vars = {
   'dart_sdk_revision': '37f38201922b071c5494e35fe09b56336f03a4f6',
   'dart_sdk_git': 'git@github.com:shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
-  'updater_rev': '15b2f6bfaa29a7b245993db1a67279bdab6f9949',
+  'updater_rev': 'b4024cf4998bf4ee521752b7d607019861ccb44c',
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/shell/common/shorebird.cc
+++ b/shell/common/shorebird.cc
@@ -39,15 +39,21 @@ extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
 }
 #endif
 
-void ConfigureShorebird(std::string cache_path,
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
                         flutter::Settings& settings,
                         const std::string& shorebird_yaml,
                         const std::string& version,
                         const std::string& version_code) {
-  auto cache_dir =
-      fml::paths::JoinPaths({std::move(cache_path), "shorebird_updater"});
+  auto shorebird_updater_dir_name = "shorebird_updater";
 
-  fml::CreateDirectory(fml::paths::GetCachesDirectory(), {"shorebird_updater"},
+  auto code_cache_dir = fml::paths::JoinPaths(
+      {std::move(code_cache_path), shorebird_updater_dir_name});
+  auto app_storage_dir = fml::paths::JoinPaths(
+      {std::move(app_storage_path), shorebird_updater_dir_name});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(),
+                       {shorebird_updater_dir_name},
                        fml::FilePermission::kReadWrite);
 
   // Using a block to make AppParameters lifetime explicit.
@@ -57,7 +63,8 @@ void ConfigureShorebird(std::string cache_path,
     // We could also pass these separately through to the updater if needed.
     auto release_version = version + "+" + version_code;
     app_parameters.release_version = release_version.c_str();
-    app_parameters.cache_dir = cache_dir.c_str();
+    app_parameters.code_cache_dir = code_cache_dir.c_str();
+    app_parameters.app_storage_dir = app_storage_dir.c_str();
 
     // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
     std::vector<const char*> c_paths{};

--- a/shell/common/shorebird.h
+++ b/shell/common/shorebird.h
@@ -5,7 +5,8 @@
 
 namespace flutter {
 
-void ConfigureShorebird(std::string cache_path,
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
                         flutter::Settings& settings,
                         const std::string& shorebird_yaml,
                         const std::string& version,

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -123,16 +123,17 @@ void FlutterMain::Init(JNIEnv* env,
   flutter::DartCallbackCache::SetCachePath(
       fml::jni::JavaStringToString(env, appStoragePath));
 
-  auto android_cache_path = fml::jni::JavaStringToString(env, appStoragePath);
-  fml::paths::InitializeAndroidCachesPath(android_cache_path);
+  auto code_cache_path = fml::jni::JavaStringToString(env, engineCachesPath);
+  auto app_storage_path = fml::jni::JavaStringToString(env, appStoragePath);
+  fml::paths::InitializeAndroidCachesPath(code_cache_path);
 
 #if FLUTTER_RELEASE
   std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
   std::string version_string = fml::jni::JavaStringToString(env, version);
   std::string version_code_string =
       fml::jni::JavaStringToString(env, versionCode);
-  ConfigureShorebird(android_cache_path, settings, shorebird_yaml,
-                     version_string, version_code_string);
+  ConfigureShorebird(code_cache_path, app_storage_path, settings,
+                     shorebird_yaml, version_string, version_code_string);
 #endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -123,7 +123,7 @@ void FlutterMain::Init(JNIEnv* env,
   flutter::DartCallbackCache::SetCachePath(
       fml::jni::JavaStringToString(env, appStoragePath));
 
-  auto android_cache_path = fml::jni::JavaStringToString(env, engineCachesPath);
+  auto android_cache_path = fml::jni::JavaStringToString(env, appStoragePath);
   fml::paths::InitializeAndroidCachesPath(android_cache_path);
 
 #if FLUTTER_RELEASE

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -176,7 +176,10 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
                                                              encoding:NSUTF8StringEncoding
                                                                 error:nil];
   if (shorebirdYamlContents != nil) {
-    flutter::ConfigureShorebird(cache_path, settings, shorebirdYamlContents.UTF8String,
+    // Note: we intentionally pass cache_path twice. We provide two different directories
+    //   to ConfigureShorebird because Android differentiates between data that persists
+    //   between releases and data that does not. iOS does not make this distinction.
+    flutter::ConfigureShorebird(cache_path, cache_path, settings, shorebirdYamlContents.UTF8String,
                                 appVersion.UTF8String, appBuildNumber.UTF8String);
   } else {
     NSLog(@"Failed to find shorebird.yaml, not starting updater.");


### PR DESCRIPTION
This changes our `state.json` storage location from `/data/user/0/com.example.android_clientid/code_cache/shorebird_updater` to `/data/user/0/com.example.android_clientid/files/shorebird_updater`. This is necessary because the code cache directory is cleared on every new release (see https://developer.android.com/reference/android/content/Context#getCodeCacheDir())

Fixes https://github.com/shorebirdtech/shorebird/issues/1239