### PR TITLE
feat: expose analyze_snapshot in build

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -88,14 +88,10 @@ group("flutter") {
 
         # path_ops
         "//flutter/tools/path_ops",
-      ]
 
-      if (host_os == "linux") {
-        public_deps += [
-          # Built alongside gen_snapshot for 64 bit targets
-          "//third_party/dart/runtime/bin:analyze_snapshot",
-        ]
-      }
+        # Built alongside gen_snapshot arm64 targets.
+        "//third_party/dart/runtime/bin:analyze_snapshot",
+      ]
 
       if (full_dart_sdk) {
         public_deps += [ "//flutter/web_sdk" ]

--- a/DEPS
+++ b/DEPS
@@ -20,7 +20,7 @@ vars = {
   'ocmock_git': 'https://github.com/erikdoe/ocmock.git',
   'skia_revision': '5046d9fc1551e025263a21eb0bb9f0b63569600e',
 
-  'dart_sdk_revision': '2e97fbc93ab28cbd338c4aec9064730f9c0e36df',
+  'dart_sdk_revision': '35fc84d82f1fecdf0f0bf7ecf1b540eaad99d5bb',
   'dart_sdk_git': 'git@github.com:shorebirdtech/dart-sdk.git',
   'updater_git': 'https://github.com/shorebirdtech/updater.git',
   'updater_rev': 'd785568094c176d956ccf7ae918bf8d64c0d09b7',

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,7 +37,7 @@ group("generate_snapshot_bins") {
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
-  if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+  if (target_cpu == "arm64") {
     deps +=
         [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]
   }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -726,7 +726,7 @@ if (target_cpu != "x86") {
   }
 }
 
-if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+if (target_cpu == "arm64") {
   zip_bundle("analyze_snapshot") {
     deps =
         [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]


### PR DESCRIPTION
It's not yet bundled/uploaded, but this includes Dart with mach-o support as well
as exposes analyze_snapshot in the build.  The next patch will bundle it as an artifact.