### PR TITLE
Add analyze_snapshot to new_gen_snapshot target

### DIFF
--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -688,12 +688,23 @@ if (target_cpu != "x86") {
 
   # TODO(godofredoc): Remove gen_snapshot and rename new_gen_snapshot when v2 migration is complete.
   # BUG: https://github.com/flutter/flutter/issues/105351
+  # This has a somewhat misleading name. We (shorebird) have updated this target
+  # to include analyze_snapshot as well as gen_snapshot. Because this target is
+  # used elsewhere in the toolchain, we did not rename it.
   zip_bundle("new_gen_snapshot") {
     gen_snapshot_bin = "gen_snapshot"
     gen_snapshot_out_dir = get_label_info(
             "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
             "root_out_dir")
     gen_snapshot_path = rebase_path("$gen_snapshot_out_dir/$gen_snapshot_bin")
+
+    analyze_snapshot_bin = "analyze_snapshot"
+    analyze_snapshot_out_dir =
+        get_label_info(
+            "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+    analyze_snapshot_path =
+        rebase_path("$analyze_snapshot_out_dir/$analyze_snapshot_bin")
 
     if (host_os == "linux") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/linux-x64.zip"
@@ -703,6 +714,8 @@ if (target_cpu != "x86") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/windows-x64.zip"
       gen_snapshot_bin = "gen_snapshot.exe"
       gen_snapshot_path = rebase_path("$root_out_dir/$gen_snapshot_bin")
+      analyze_snapshot_bin = "analyze_snapshot.exe"
+      analyze_snapshot_path = rebase_path("$root_out_dir/$analyze_snapshot_bin")
     }
 
     files = [
@@ -710,9 +723,16 @@ if (target_cpu != "x86") {
         source = gen_snapshot_path
         destination = gen_snapshot_bin
       },
+      {
+        source = analyze_snapshot_path
+        destination = analyze_snapshot_bin
+      },
     ]
 
-    deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
+    deps = [
+      "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)",
+      "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)",
+    ]
 
     if (host_os == "mac") {
       deps += [ ":android_entitlement_config" ]


### PR DESCRIPTION
This allows us to bundle the analyze_snapshot executable with gen_snapshot in $HOST_ARCH.zip