### PR TITLE
Add create_arm_analyze_snapshot to generate analyze_snapshot_arm64 bin

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -33,7 +33,10 @@ group("generate_snapshot_bins") {
     deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_gen_snapshot" ]
+    deps += [
+      ":create_arm_analyze_snapshot",
+      ":create_arm_gen_snapshot",
+    ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
@@ -268,6 +271,26 @@ if (host_os == "mac" && target_os != "mac" &&
     sources = [ "${host_output_dir}/gen_snapshot" ]
     outputs = [ "${host_output_dir}/gen_snapshot_${target_cpu_suffix}" ]
     deps = [ "//third_party/dart/runtime/bin:gen_snapshot($host_toolchain)" ]
+    visibility = [ ":*" ]
+  }
+
+  copy("create_arm_analyze_snapshot") {
+    # The toolchain-specific output directory. For cross-compiles, this is a
+    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+    host_output_dir = get_label_info(
+            "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+
+    # Determine suffixed output gen_snapshot name.
+    target_cpu_suffix = target_cpu
+    if (target_cpu == "arm") {
+      target_cpu_suffix = "armv7"
+    }
+
+    sources = [ "${host_output_dir}/analyze_snapshot" ]
+    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
+    deps =
+        [ "//third_party/dart/runtime/bin:analyze_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
 }


### PR DESCRIPTION
Creates `create_arm_analyze_snapshot` using `create_arm_gen_snapshot` as a model and includes it in the `generate_snapshot_bins` rule.