### PR TITLE
fix: Teach flutter engine to read linker header

### DIFF
--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -69,13 +69,16 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     if (leaked_elf == nullptr) {
       const char* error = nullptr;
       // vmcode files are elf files prefixed with a shorebird linker header.
-      auto elf_mapping = GetFileMapping(native_library_path.back(), false /* executable */);
-      int elf_file_offset = Shorebird_ReadLinkHeader(elf_mapping->GetMapping(), elf_mapping->GetSize());
+      auto elf_mapping =
+          GetFileMapping(native_library_path.back(), false /* executable */);
+      int elf_file_offset = Shorebird_ReadLinkHeader(elf_mapping->GetMapping(),
+                                                     elf_mapping->GetSize());
 
-      leaked_elf = Dart_LoadELF(native_library_path.back().c_str(), elf_file_offset, &error,
-                                &vm_snapshot_data, &vm_snapshot_instrs,
-                                &vm_isolate_data, &vm_isolate_instrs,
-                                /* load as read-only, not rx */ true);
+      leaked_elf =
+          Dart_LoadELF(native_library_path.back().c_str(), elf_file_offset,
+                       &error, &vm_snapshot_data, &vm_snapshot_instrs,
+                       &vm_isolate_data, &vm_isolate_instrs,
+                       /* load as read-only, not rx */ true);
       if (leaked_elf != nullptr) {
         FML_LOG(INFO) << "Loaded ELF";
       } else {

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -61,6 +61,13 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
 #if FML_OS_IOS
   // Don't use our terrible elf hacks when loading from the IPA itself.
   if (native_library_path.back().find(".framework") == std::string::npos) {
+    // We use this terrible hack to load in the patch and then extract the
+    // symbols from it when the path is not App.framework/App but rather
+    // foo.vmcode, etc. (We could check for .vmcode instead of lack of
+    // .framework.)  We read the symbols into static variables, but then I
+    // believe we need to hold onto the ELF itself, otherwise the symbols
+    // become invalid.
+    // "leaked_elf" is meant to indicate that we're not freeing the ELF.
     static Dart_LoadedElf* leaked_elf = nullptr;
     static const uint8_t* vm_snapshot_data = nullptr;
     static const uint8_t* vm_snapshot_instrs = nullptr;

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -68,7 +68,11 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     static const uint8_t* vm_isolate_instrs = nullptr;
     if (leaked_elf == nullptr) {
       const char* error = nullptr;
-      leaked_elf = Dart_LoadELF(native_library_path.back().c_str(), 0, &error,
+      // vmcode files are elf files prefixed with a shorebird linker header.
+      auto elf_mapping = GetFileMapping(native_library_path.back(), false /* executable */);
+      int elf_file_offset = Shorebird_ReadLinkHeader(elf_mapping->GetMapping(), elf_mapping->GetSize());
+
+      leaked_elf = Dart_LoadELF(native_library_path.back().c_str(), elf_file_offset, &error,
                                 &vm_snapshot_data, &vm_snapshot_instrs,
                                 &vm_isolate_data, &vm_isolate_instrs,
                                 /* load as read-only, not rx */ true);


### PR DESCRIPTION
Re-enabled reading the base snapshot and also taught the flutter engine how to read the linker header.

This still crashes (although probably not for the reason I left a comment about).  But this is a definite
improvement and I think we should land it.