### PR TITLE
fix: patches should not be executable

### DIFF
--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -85,7 +85,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
           Dart_LoadELF(native_library_path.back().c_str(), elf_file_offset,
                        &error, &vm_snapshot_data, &vm_snapshot_instrs,
                        &vm_isolate_data, &vm_isolate_instrs,
-                       /* load as read-only, not rx */ true);
+                       /* load as read-only, not rx */ false);
       if (leaked_elf != nullptr) {
         FML_LOG(INFO) << "Loaded ELF";
       } else {


### PR DESCRIPTION
At some point during the mixed-mode landing I flipped the meaning
of the bool (one reason why bools should never be used as arguments)
from "true" meaning "read only" to "true" meaning "mark executable"
and then failed to clean up this code.

This now correctly loads a patch as non-executable which is necessary
to not anger iOS (which will enforce that writable memory can never
be marked executable).