### PR TITLE
fix: shorebird launch reporting

### DIFF
--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -429,9 +429,11 @@ Shell::Shell(DartVMRef vm,
       weak_factory_(this) {
 // FIXME: This is probably the wrong place to hook into.
 #if FML_OS_ANDROID || FML_OS_IOS
-  if (!vm) {
+  if (!vm_) {
+    FML_LOG(ERROR) << "Shorebird reporting launch failure\n";
     shorebird_report_launch_failure();
   } else {
+    FML_LOG(ERROR) << "Shorebird reporting launch success\n";
     shorebird_report_launch_success();
   }
 #endif

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -430,10 +430,8 @@ Shell::Shell(DartVMRef vm,
 // FIXME: This is probably the wrong place to hook into.
 #if FML_OS_ANDROID || FML_OS_IOS
   if (!vm_) {
-    FML_LOG(ERROR) << "Shorebird reporting launch failure\n";
     shorebird_report_launch_failure();
   } else {
-    FML_LOG(ERROR) << "Shorebird reporting launch success\n";
     shorebird_report_launch_success();
   }
 #endif


### PR DESCRIPTION
Previously we were checking `vm` which will always be null since it is moved right before we check it. It was causing us to incorrectly always report a launch failure