### PR TITLE
chore: remove print of current patch number

### DIFF
--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -145,13 +145,6 @@ void ConfigureShorebird(std::string code_cache_path,
     std::string active_path = c_active_path;
     shorebird_free_string(c_active_path);
     FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
-    size_t c_patch_number = shorebird_next_boot_patch_number();
-    // FIXME: use a constant for this.
-    // 0 means no patch is available.
-    if (c_patch_number != 0) {
-      FML_LOG(INFO) << "Shorebird updater: active patch number: "
-                    << c_patch_number;
-    }
 
 #if FML_OS_IOS
     // On iOS we add the patch to the front of the list instead of clearing


### PR DESCRIPTION
Because we perform patch validation whenever the Updater is asked for the next boot patch, asking for the next boot path patch and the next boot patch number causes validation to be performed twice. Before the introduction of patch signing, this was very cheap, as we'd only verify that the file's size hasn't changed. Now that we're checking the signature of the patch hash, we're hashing the entire inflated patch when validating, which is expensive.