### PR TITLE
fix: update how we generate analyze_snapshot

### DIFF
--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -237,7 +237,7 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
       ":create_macos_gen_snapshot_x64_${target_cpu}",
     ]
   }
-  
+
   # Added by shorebird.
   # analyze_snapshot targets below were copied from the gen_snapshot targets
   # above to allow us to include analyze_snapshot in the artifacts generated
@@ -265,17 +265,20 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
       output_dir = get_label_info(analyze_snapshot_target, "root_out_dir")
 
       sources = [ "${output_dir}/${analyze_snapshot_target_name}" ]
-      outputs =
-          [ "${root_out_dir}/artifacts_$host_cpu/analyze_snapshot_${target_cpu}" ]
+      outputs = [
+        "${root_out_dir}/artifacts_$host_cpu/analyze_snapshot_${target_cpu}",
+      ]
       deps = [ analyze_snapshot_target ]
     }
   }
 
-  build_mac_analyze_snapshot("create_macos_analyze_snapshot_arm64_${target_cpu}") {
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_arm64_${target_cpu}") {
     host_arch = "arm64"
   }
 
-  build_mac_analyze_snapshot("create_macos_analyze_snapshot_x64_${target_cpu}") {
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_x64_${target_cpu}") {
     host_arch = "x64"
   }
 
@@ -284,9 +287,11 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
     outputs = [ "${root_out_dir}/analyze_snapshot_${target_cpu}" ]
     args = [
       "--in-arm64",
-      rebase_path("${root_out_dir}/artifacts_arm64/analyze_snapshot_${target_cpu}"),
+      rebase_path(
+          "${root_out_dir}/artifacts_arm64/analyze_snapshot_${target_cpu}"),
       "--in-x64",
-      rebase_path("${root_out_dir}/artifacts_x64/analyze_snapshot_${target_cpu}"),
+      rebase_path(
+          "${root_out_dir}/artifacts_x64/analyze_snapshot_${target_cpu}"),
       "--out",
       rebase_path("${root_out_dir}/analyze_snapshot_${target_cpu}"),
     ]

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -34,15 +34,13 @@ group("generate_snapshot_bins") {
   # For macOS target builds: needed for both target CPUs (arm64, x64).
   # For iOS, Android target builds: all AOT target CPUs are arm/arm64.
   if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
-    deps += [ ":create_macos_gen_snapshots" ]
+    deps += [
+      ":create_macos_analyze_snapshots",
+      ":create_macos_gen_snapshots",
+    ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
-  }
-
-  if (host_os == "mac" && target_os != "mac" &&
-      (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_analyze_snapshot" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
@@ -181,25 +179,6 @@ if (host_os == "mac" && target_os != "mac" &&
     deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
-
-  copy("create_arm_analyze_snapshot") {
-    # The toolchain-specific output directory. For cross-compiles, this is a
-    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
-    host_output_dir = get_label_info(
-            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
-            "root_out_dir")
-
-    # Determine suffixed output gen_snapshot name.
-    target_cpu_suffix = target_cpu
-    if (target_cpu == "arm") {
-      target_cpu_suffix = "armv7"
-    }
-
-    sources = [ "${host_output_dir}/analyze_snapshot" ]
-    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
-    deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
-    visibility = [ ":*" ]
-  }
 }
 
 # Creates a `gen_snapshot` binary suffixed with the target CPU architecture.
@@ -256,6 +235,64 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
     deps = [
       ":create_macos_gen_snapshot_arm64_${target_cpu}",
       ":create_macos_gen_snapshot_x64_${target_cpu}",
+    ]
+  }
+  
+  # Added by shorebird.
+  # analyze_snapshot targets below were copied from the gen_snapshot targets
+  # above to allow us to include analyze_snapshot in the artifacts generated
+  # for create_ios_framework.py.
+  template("build_mac_analyze_snapshot") {
+    assert(defined(invoker.host_arch))
+    host_cpu = invoker.host_arch
+
+    build_toolchain = "//build/toolchain/mac:clang_$host_cpu"
+    analyze_snapshot_target_name = "analyze_snapshot"
+
+    # At this point, the gen_snapshot equivalent changes
+    # gen_ snapshot_target_name to "gen_snapshot_host_targeting_host". There is
+    # no equivalent for analyze_snapshot, so we don't do that here.
+    #
+    # It's unclear whether we need to do so now, but we didn't previously, so
+    # we're not doing it now until we have a reason to.
+
+    analyze_snapshot_target =
+        "$dart_src/runtime/bin:$analyze_snapshot_target_name($build_toolchain)"
+
+    copy(target_name) {
+      # The toolchain-specific output directory. For cross-compiles, this is a
+      # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+      output_dir = get_label_info(analyze_snapshot_target, "root_out_dir")
+
+      sources = [ "${output_dir}/${analyze_snapshot_target_name}" ]
+      outputs =
+          [ "${root_out_dir}/artifacts_$host_cpu/analyze_snapshot_${target_cpu}" ]
+      deps = [ analyze_snapshot_target ]
+    }
+  }
+
+  build_mac_analyze_snapshot("create_macos_analyze_snapshot_arm64_${target_cpu}") {
+    host_arch = "arm64"
+  }
+
+  build_mac_analyze_snapshot("create_macos_analyze_snapshot_x64_${target_cpu}") {
+    host_arch = "x64"
+  }
+
+  action("create_macos_analyze_snapshots") {
+    script = "//flutter/sky/tools/create_macos_binary.py"
+    outputs = [ "${root_out_dir}/analyze_snapshot_${target_cpu}" ]
+    args = [
+      "--in-arm64",
+      rebase_path("${root_out_dir}/artifacts_arm64/analyze_snapshot_${target_cpu}"),
+      "--in-x64",
+      rebase_path("${root_out_dir}/artifacts_x64/analyze_snapshot_${target_cpu}"),
+      "--out",
+      rebase_path("${root_out_dir}/analyze_snapshot_${target_cpu}"),
+    ]
+    deps = [
+      ":create_macos_analyze_snapshot_arm64_${target_cpu}",
+      ":create_macos_analyze_snapshot_x64_${target_cpu}",
     ]
   }
 }


### PR DESCRIPTION
Due to a change in `lib/snapshot/BUILD.gn`, we were no longer building `analyze_snapshot` for iOS. This change replaces our previous `create_arm_analyze_snapshot` with something more in line with the ~equivalent `create_macos_gen_snapshots`. 