### PR TITLE
feat: build windows targets

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -112,14 +112,10 @@ group("flutter") {
 
         # path_ops
         "//flutter/tools/path_ops",
-      ]
 
-      if (host_os == "linux") {
-        public_deps += [
-          # Built alongside gen_snapshot for 64 bit targets
-          "$dart_src/runtime/bin:analyze_snapshot",
-        ]
-      }
+        # Built alongside gen_snapshot arm64 targets.
+        "$dart_src/runtime/bin:analyze_snapshot",
+      ]
 
       if (full_dart_sdk) {
         public_deps += [ "//flutter/web_sdk" ]
@@ -193,6 +189,7 @@ group("unittests") {
       "//flutter/runtime:no_dart_plugin_registrant_unittests",
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
+      "//flutter/shell/common/shorebird:shorebird_unittests",
       "//flutter/shell/platform/embedder:embedder_a11y_unittests",
       "//flutter/shell/platform/embedder:embedder_proctable_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
@@ -317,5 +314,21 @@ if (host_os == "win") {
     gen_snapshot_out_dir = get_label_info(_gen_snapshot_target, "root_out_dir")
     sources = [ "$gen_snapshot_out_dir/gen_snapshot.exe" ]
     outputs = [ "$root_build_dir/gen_snapshot/gen_snapshot.exe" ]
+  }
+}
+
+# A top-level target for analyze_snapshot, modeled after the gen_snapshot
+# target above.
+if (host_os == "win") {
+  _analyze_snapshot_target =
+      "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)"
+
+  copy("analyze_snapshot") {
+    deps = [ _analyze_snapshot_target ]
+
+    analyze_snapshot_out_dir =
+        get_label_info(_analyze_snapshot_target, "root_out_dir")
+    sources = [ "$analyze_snapshot_out_dir/analyze_snapshot.exe" ]
+    outputs = [ "$root_build_dir/analyze_snapshot/analyze_snapshot.exe" ]
   }
 }

--- a/DEPS
+++ b/DEPS
@@ -279,7 +279,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f85c3be4bf808add6ba867b8ff7943fd235b7b5e',
+  'src': 'https://github.com/shorebirdtech/buildroot.git' + '@' + '4c5c8abd2ab1ac7c2c029503c71450a87bf94307',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',

--- a/DEPS
+++ b/DEPS
@@ -15,6 +15,10 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': '6062afaa505bf7e6c727a20cafe4c7bee0f02df8',
+  "dart_sdk_revision": "4f9b5084a041a0e7cc26295da1da9109df43ac4c",
+  "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
+  "updater_git": "https://github.com/shorebirdtech/updater.git",
+  "updater_rev": "1e4efce65f28d54c7a806ea05defd2ca3eb94595",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
@@ -258,22 +262,20 @@ vars = {
   'fuchsia_gn_sdk_version': 'tHRCseOuPnZ5H4a7kb4Zl6YQ2rhEDWIzcEX3G9NPFhkC',
 }
 
-gclient_gn_args_file = 'src/flutter/third_party/dart/build/config/gclient_args.gni'
-gclient_gn_args = [
-  'checkout_llvm'
-]
+gclient_gn_args_file = "src/flutter/third_party/dart/build/config/gclient_args.gni"
+gclient_gn_args = ["checkout_llvm"]
 
 # Only these hosts are allowed for dependencies in this DEPS file.
 # If you need to add a new host, contact chrome infrastructure team.
 allowed_hosts = [
-  'boringssl.googlesource.com',
-  'chrome-infra-packages.appspot.com',
-  'chromium.googlesource.com',
-  'dart.googlesource.com',
-  'flutter.googlesource.com',
-  'llvm.googlesource.com',
-  'skia.googlesource.com',
-  'swiftshader.googlesource.com',
+    "boringssl.googlesource.com",
+    "chrome-infra-packages.appspot.com",
+    "chromium.googlesource.com",
+    "dart.googlesource.com",
+    "flutter.googlesource.com",
+    "llvm.googlesource.com",
+    "skia.googlesource.com",
+    "swiftshader.googlesource.com",
 ]
 
 deps = {
@@ -339,7 +341,7 @@ deps = {
   #  Var('flutter_git') + '/third_party/protobuf-gn' + '@' + Var('dart_protobuf_gn_rev'),
 
   'src/flutter/third_party/dart':
-   Var('dart_git') + '/sdk.git' + '@' + Var('dart_revision'),
+   Var('dart_sdk_git') + '@' + Var('dart_sdk_revision'),
 
   # WARNING: Unused Dart dependencies in the list below till "WARNING:" marker are removed automatically - see create_updated_flutter_deps.py.
 
@@ -631,6 +633,9 @@ deps = {
 
   'src/flutter/third_party/ocmock':
    Var('flutter_git') + '/third_party/ocmock' + '@' +  Var('ocmock_rev'),
+
+   'src/third_party/updater':
+   Var('updater_git') + '@' + Var('updater_rev'),
 
   'src/flutter/third_party/libjpeg-turbo/src':
    Var('flutter_git') + '/third_party/libjpeg-turbo' + '@' + '0fb821f3b2e570b2783a94ccd9a2fb1f4916ae9f',
@@ -1018,157 +1023,165 @@ deps = {
 }
 
 recursedeps = [
-  'src/flutter/third_party/vulkan-deps',
+    "src/flutter/third_party/vulkan-deps",
 ]
 
 hooks = [
-  {
-    # Generate the Dart SDK's .dart_tool/package_confg.json file.
-    'name': 'Generate .dart_tool/package_confg.json',
-    'pattern': '.',
-    'action': ['python3', 'src/flutter/third_party/dart/tools/generate_package_config.py'],
-  },
-  {
-    # Generate the sdk/version file.
-    'name': 'Generate sdk/version',
-    'pattern': '.',
-    'action': ['python3', 'src/flutter/third_party/dart/tools/generate_sdk_version_file.py'],
-  },
-  {
-    # Update the Windows toolchain if necessary.
-    'name': 'win_toolchain',
-    'condition': 'download_windows_deps',
-    'pattern': '.',
-    'action': ['python3', 'src/build/vs_toolchain.py', 'update'],
-  },
-  {
-    'name': 'dia_dll',
-    'pattern': '.',
-    'condition': 'download_windows_deps',
-    'action': [
-      'python3',
-      'src/flutter/tools/dia_dll.py',
-    ],
-  },
-  {
-    'name': 'linux_sysroot_x64',
-    'pattern': '.',
-    'condition': 'download_linux_deps',
-    'action': [
-      'python3',
-      'src/build/linux/sysroot_scripts/install-sysroot.py',
-      '--arch=x64'],
-  },
-  {
-    'name': 'linux_sysroot_arm64',
-    'pattern': '.',
-    'condition': 'download_linux_deps',
-    'action': [
-      'python3',
-      'src/build/linux/sysroot_scripts/install-sysroot.py',
-      '--arch=arm64'],
-  },
-  {
-    'name': 'pub get --offline',
-    'pattern': '.',
-    'action': [
-      'python3',
-      'src/flutter/tools/pub_get_offline.py',
-    ]
-  },
-  {
-    'name': 'Download Fuchsia SDK',
-    'pattern': '.',
-    'condition': 'download_fuchsia_deps and download_fuchsia_sdk',
-    'action': [
-      'python3',
-      'src/flutter/tools/download_fuchsia_sdk.py',
-      '--fail-loudly',
-      '--verbose',
-      '--host-os',
-      Var('host_os'),
-      '--fuchsia-sdk-path',
-      Var('fuchsia_sdk_path'),
-    ]
-  },
-  {
-    'name': 'Activate Emscripten SDK',
-    'pattern': '.',
-    'condition': 'download_emsdk',
-    'action': [
-      'python3',
-      'src/flutter/tools/activate_emsdk.py',
-    ]
-  },
-  {
-    'name': 'Setup githooks',
-    'pattern': '.',
-    'condition': 'setup_githooks',
-    'action': [
-      'python3',
-      'src/flutter/tools/githooks/setup.py',
-    ]
-  },
-  {
-    'name': 'impeller-cmake-example submodules',
-    'pattern': '.',
-    'condition': 'download_impeller_cmake_example',
-    'action': [
-      'python3',
-      'src/flutter/ci/impeller_cmake_build_test.py',
-      '--path',
-      'flutter/third_party/impeller-cmake-example',
-      '--setup',
-    ]
-  },
-  {
-    'name': 'Download Fuchsia system images',
-    'pattern': '.',
-    'condition': 'run_fuchsia_emu',
-    'action': [
-      'env',
-      'DOWNLOAD_FUCHSIA_SDK={download_fuchsia_sdk}',
-      'FUCHSIA_SDK_PATH={fuchsia_sdk_path}',
-      'python3',
-      'src/flutter/tools/fuchsia/with_envs.py',
-      'src/flutter/tools/fuchsia/test_scripts/update_product_bundles.py',
-      'terminal.x64,terminal.qemu-arm64',
-    ]
-  },
-  # The following two scripts check if they are running in the LUCI
-  # environment, and do nothing if so. This is because Xcode is not yet
-  # installed in CI when these hooks are run.
-  {
-    'name': 'Find the iOS device SDKs',
-    'pattern': '.',
-    'condition': 'host_os == "mac"',
-    'action': [
-      'python3',
-      'src/build/config/ios/ios_sdk.py',
-      # This cleans up entries under flutter/prebuilts for this script and the
-      # following script.
-      '--as-gclient-hook'
-    ]
-  },
-  {
-    'name': 'Find the macOS SDK',
-    'pattern': '.',
-    'condition': 'host_os == "mac"',
-    'action': [
-      'python3',
-      'src/build/mac/find_sdk.py',
-      '--as-gclient-hook',
-      Var('mac_sdk_min')
-    ]
-  },
-  {
-    'name': 'Generate Fuchsia GN build rules',
-    'pattern': '.',
-    'condition': 'download_fuchsia_deps',
-    'action': [
-      'python3',
-      'src/flutter/tools/fuchsia/with_envs.py',
-      'src/flutter/tools/fuchsia/test_scripts/gen_build_defs.py',
-    ],
-  },
+    {
+        # Generate the Dart SDK's .dart_tool/package_confg.json file.
+        "name": "Generate .dart_tool/package_confg.json",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/third_party/dart/tools/generate_package_config.py",
+        ],
+    },
+    {
+        # Generate the sdk/version file.
+        "name": "Generate sdk/version",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/third_party/dart/tools/generate_sdk_version_file.py",
+        ],
+    },
+    {
+        # Update the Windows toolchain if necessary.
+        "name": "win_toolchain",
+        "condition": "download_windows_deps",
+        "pattern": ".",
+        "action": ["python3", "src/build/vs_toolchain.py", "update"],
+    },
+    {
+        "name": "dia_dll",
+        "pattern": ".",
+        "condition": "download_windows_deps",
+        "action": [
+            "python3",
+            "src/flutter/tools/dia_dll.py",
+        ],
+    },
+    {
+        "name": "linux_sysroot_x64",
+        "pattern": ".",
+        "condition": "download_linux_deps",
+        "action": [
+            "python3",
+            "src/build/linux/sysroot_scripts/install-sysroot.py",
+            "--arch=x64",
+        ],
+    },
+    {
+        "name": "linux_sysroot_arm64",
+        "pattern": ".",
+        "condition": "download_linux_deps",
+        "action": [
+            "python3",
+            "src/build/linux/sysroot_scripts/install-sysroot.py",
+            "--arch=arm64",
+        ],
+    },
+    {
+        "name": "pub get --offline",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/tools/pub_get_offline.py",
+        ],
+    },
+    {
+        "name": "Download Fuchsia SDK",
+        "pattern": ".",
+        "condition": "download_fuchsia_deps and download_fuchsia_sdk",
+        "action": [
+            "python3",
+            "src/flutter/tools/download_fuchsia_sdk.py",
+            "--fail-loudly",
+            "--verbose",
+            "--host-os",
+            Var("host_os"),
+            "--fuchsia-sdk-path",
+            Var("fuchsia_sdk_path"),
+        ],
+    },
+    {
+        "name": "Activate Emscripten SDK",
+        "pattern": ".",
+        "condition": "download_emsdk",
+        "action": [
+            "python3",
+            "src/flutter/tools/activate_emsdk.py",
+        ],
+    },
+    {
+        "name": "Setup githooks",
+        "pattern": ".",
+        "condition": "setup_githooks",
+        "action": [
+            "python3",
+            "src/flutter/tools/githooks/setup.py",
+        ],
+    },
+    {
+        "name": "impeller-cmake-example submodules",
+        "pattern": ".",
+        "condition": "download_impeller_cmake_example",
+        "action": [
+            "python3",
+            "src/flutter/ci/impeller_cmake_build_test.py",
+            "--path",
+            "flutter/third_party/impeller-cmake-example",
+            "--setup",
+        ],
+    },
+    {
+        "name": "Download Fuchsia system images",
+        "pattern": ".",
+        "condition": "run_fuchsia_emu",
+        "action": [
+            "env",
+            "DOWNLOAD_FUCHSIA_SDK={download_fuchsia_sdk}",
+            "FUCHSIA_SDK_PATH={fuchsia_sdk_path}",
+            "python3",
+            "src/flutter/tools/fuchsia/with_envs.py",
+            "src/flutter/tools/fuchsia/test_scripts/update_product_bundles.py",
+            "terminal.x64,terminal.qemu-arm64",
+        ],
+    },
+    # The following two scripts check if they are running in the LUCI
+    # environment, and do nothing if so. This is because Xcode is not yet
+    # installed in CI when these hooks are run.
+    {
+        "name": "Find the iOS device SDKs",
+        "pattern": ".",
+        "condition": 'host_os == "mac"',
+        "action": [
+            "python3",
+            "src/build/config/ios/ios_sdk.py",
+            # This cleans up entries under flutter/prebuilts for this script and the
+            # following script.
+            "--as-gclient-hook",
+        ],
+    },
+    {
+        "name": "Find the macOS SDK",
+        "pattern": ".",
+        "condition": 'host_os == "mac"',
+        "action": [
+            "python3",
+            "src/build/mac/find_sdk.py",
+            "--as-gclient-hook",
+            Var("mac_sdk_min"),
+        ],
+    },
+    {
+        "name": "Generate Fuchsia GN build rules",
+        "pattern": ".",
+        "condition": "download_fuchsia_deps",
+        "action": [
+            "python3",
+            "src/flutter/tools/fuchsia/with_envs.py",
+            "src/flutter/tools/fuchsia/test_scripts/gen_build_defs.py",
+        ],
+    },
 ]

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -45,6 +45,7 @@ generated_file("artifacts_entitlement_config") {
 if (build_engine_artifacts) {
   zip_bundle("artifacts") {
     deps = [
+      "$dart_src/runtime/bin:analyze_snapshot",
       "$dart_src/runtime/bin:gen_snapshot",
       "//flutter/flutter_frontend_server:frontend_server",
       "//flutter/impeller/compiler:impellerc",
@@ -139,6 +140,10 @@ if (build_engine_artifacts) {
     if (host_os == "mac") {
       deps += [ ":artifacts_entitlement_config" ]
       files += [
+        {
+          source = "$root_out_dir/analyze_snapshot$exe"
+          destination = "analyze_snapshot$exe"
+        },
         {
           source = "$target_gen_dir/entitlements.txt"
           destination = "entitlements.txt"
@@ -308,13 +313,24 @@ if (is_mac) {
 }
 
 if (host_os == "win") {
+  # This rule archives both gen_snapshot *and* analyze_snapshot. The name is
+  # misleading. We (shorebird) have updated this rule to include
+  # analyze_snapshot but did not update the name because it is referenced
+  # elsewhere in the tooling.
   zip_bundle("archive_win_gen_snapshot") {
-    deps = [ "//flutter:gen_snapshot" ]
+    deps = [
+      "//flutter:analyze_snapshot",
+      "//flutter:gen_snapshot",
+    ]
     output = "$full_target_platform_name-$flutter_runtime_mode/windows-x64.zip"
     files = [
       {
         source = "$root_out_dir/gen_snapshot/gen_snapshot.exe"
         destination = "gen_snapshot.exe"
+      },
+      {
+        source = "$root_out_dir/analyze_snapshot/analyze_snapshot.exe"
+        destination = "analyze_snapshot.exe"
       },
     ]
   }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,10 +37,11 @@ group("generate_snapshot_bins") {
     deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [
-      ":create_arm_analyze_snapshot",
-      ":create_arm_gen_snapshot",
-    ]
+    deps += [ ":create_arm_gen_snapshot" ]
+  }
+
+  if (host_os == "mac" && target_os != "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+    deps += [ ":create_arm_analyze_snapshot" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -34,15 +34,13 @@ group("generate_snapshot_bins") {
   # For macOS target builds: needed for both target CPUs (arm64, x64).
   # For iOS, Android target builds: all AOT target CPUs are arm/arm64.
   if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
-    deps += [ ":create_macos_gen_snapshots" ]
+    deps += [
+      ":create_macos_analyze_snapshots",
+      ":create_macos_gen_snapshots",
+    ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
-  }
-
-  if (host_os == "mac" && target_os != "mac" &&
-      (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_analyze_snapshot" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
@@ -181,25 +179,6 @@ if (host_os == "mac" && target_os != "mac" &&
     deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
-
-  copy("create_arm_analyze_snapshot") {
-    # The toolchain-specific output directory. For cross-compiles, this is a
-    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
-    host_output_dir = get_label_info(
-            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
-            "root_out_dir")
-
-    # Determine suffixed output gen_snapshot name.
-    target_cpu_suffix = target_cpu
-    if (target_cpu == "arm") {
-      target_cpu_suffix = "armv7"
-    }
-
-    sources = [ "${host_output_dir}/analyze_snapshot" ]
-    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
-    deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
-    visibility = [ ":*" ]
-  }
 }
 
 # Creates a `gen_snapshot` binary suffixed with the target CPU architecture.
@@ -256,6 +235,69 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
     deps = [
       ":create_macos_gen_snapshot_arm64_${target_cpu}",
       ":create_macos_gen_snapshot_x64_${target_cpu}",
+    ]
+  }
+
+  # Added by shorebird.
+  # analyze_snapshot targets below were copied from the gen_snapshot targets
+  # above to allow us to include analyze_snapshot in the artifacts generated
+  # for create_ios_framework.py.
+  template("build_mac_analyze_snapshot") {
+    assert(defined(invoker.host_arch))
+    host_cpu = invoker.host_arch
+
+    build_toolchain = "//build/toolchain/mac:clang_$host_cpu"
+    analyze_snapshot_target_name = "analyze_snapshot"
+
+    # At this point, the gen_snapshot equivalent changes
+    # gen_ snapshot_target_name to "gen_snapshot_host_targeting_host". There is
+    # no equivalent for analyze_snapshot, so we don't do that here.
+    #
+    # It's unclear whether we need to do so now, but we didn't previously, so
+    # we're not doing it now until we have a reason to.
+
+    analyze_snapshot_target =
+        "$dart_src/runtime/bin:$analyze_snapshot_target_name($build_toolchain)"
+
+    copy(target_name) {
+      # The toolchain-specific output directory. For cross-compiles, this is a
+      # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+      output_dir = get_label_info(analyze_snapshot_target, "root_out_dir")
+
+      sources = [ "${output_dir}/${analyze_snapshot_target_name}" ]
+      outputs = [
+        "${root_out_dir}/artifacts_$host_cpu/analyze_snapshot_${target_cpu}",
+      ]
+      deps = [ analyze_snapshot_target ]
+    }
+  }
+
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_arm64_${target_cpu}") {
+    host_arch = "arm64"
+  }
+
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_x64_${target_cpu}") {
+    host_arch = "x64"
+  }
+
+  action("create_macos_analyze_snapshots") {
+    script = "//flutter/sky/tools/create_macos_binary.py"
+    outputs = [ "${root_out_dir}/analyze_snapshot_${target_cpu}" ]
+    args = [
+      "--in-arm64",
+      rebase_path(
+          "${root_out_dir}/artifacts_arm64/analyze_snapshot_${target_cpu}"),
+      "--in-x64",
+      rebase_path(
+          "${root_out_dir}/artifacts_x64/analyze_snapshot_${target_cpu}"),
+      "--out",
+      rebase_path("${root_out_dir}/analyze_snapshot_${target_cpu}"),
+    ]
+    deps = [
+      ":create_macos_analyze_snapshot_arm64_${target_cpu}",
+      ":create_macos_analyze_snapshot_x64_${target_cpu}",
     ]
   }
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -40,7 +40,8 @@ group("generate_snapshot_bins") {
     deps += [ ":create_arm_gen_snapshot" ]
   }
 
-  if (host_os == "mac" && target_os != "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+  if (host_os == "mac" && target_os != "mac" &&
+      (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_analyze_snapshot" ]
   }
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,11 +37,14 @@ group("generate_snapshot_bins") {
     deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_gen_snapshot" ]
+    deps += [
+      ":create_arm_analyze_snapshot",
+      ":create_arm_gen_snapshot",
+    ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
-  if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+  if (target_cpu == "arm64") {
     deps += [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
   }
 }
@@ -174,6 +177,25 @@ if (host_os == "mac" && target_os != "mac" &&
     sources = [ "${host_output_dir}/gen_snapshot" ]
     outputs = [ "${host_output_dir}/gen_snapshot_${target_cpu_suffix}" ]
     deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    visibility = [ ":*" ]
+  }
+
+  copy("create_arm_analyze_snapshot") {
+    # The toolchain-specific output directory. For cross-compiles, this is a
+    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+    host_output_dir = get_label_info(
+            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+
+    # Determine suffixed output gen_snapshot name.
+    target_cpu_suffix = target_cpu
+    if (target_cpu == "arm") {
+      target_cpu_suffix = "armv7"
+    }
+
+    sources = [ "${host_output_dir}/analyze_snapshot" ]
+    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
+    deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
 }

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -6,6 +6,7 @@
 
 #include <sstream>
 
+#include <third_party/dart/runtime/bin/elf_loader.h>
 #include "flutter/fml/native_library.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
@@ -56,33 +57,93 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
-  // Ask the embedder. There is no fallback as we expect the embedders (via
-  // their embedding APIs) to just specify the mappings directly.
-  if (embedder_mapping_callback) {
-    // Note that mapping will be nullptr if the mapping callback returns an
-    // invalid mapping. If all the other methods for resolving the data also
-    // fail, the engine will stop with accompanying error logs.
-    if (auto mapping = embedder_mapping_callback()) {
-      return mapping;
-    }
-  }
+#if FML_OS_IOS || FML_OS_MACOSX
+  // Detect when we're trying to load a Shorebird patch.
+  auto patch_path = native_library_path.front();
+  bool is_patch = patch_path.find(".vmcode") != std::string::npos;
+  if (is_patch) {
+    // We use this terrible hack to load in the patch and then extract the
+    // symbols from it when the path is not App.framework/App but rather
+    // foo.vmcode, etc. We read the symbols into static variables, but then I
+    // believe we need to hold onto the ELF itself, otherwise the symbols
+    // become invalid.
+    // "leaked_elf" is meant to indicate that we're not freeing the ELF.
+    static Dart_LoadedElf* leaked_elf = nullptr;
+    // The VM Snapshot is identical for all binaries produced by a given version
+    // of Dart.  Our linker checks this and will fail to link if ever the VM
+    // snapshot changes.
+    const uint8_t* ignored_vm_data = nullptr;
+    const uint8_t* ignored_vm_instrs = nullptr;
+    static const uint8_t* isolate_data = nullptr;
+    static const uint8_t* isolate_instrs = nullptr;
+    if (leaked_elf == nullptr) {
+      const char* error = nullptr;
+      // vmcode files are elf files prefixed with a shorebird linker header.
+      auto elf_mapping = GetFileMapping(patch_path, false /* executable */);
+      int elf_file_offset = Shorebird_ReadLinkHeader(elf_mapping->GetMapping(),
+                                                     elf_mapping->GetSize());
 
-  // Attempt to open file at path specified.
-  if (!file_path.empty()) {
-    if (auto file_mapping = GetFileMapping(file_path, is_executable)) {
-      return file_mapping;
+      leaked_elf = Dart_LoadELF(patch_path.c_str(), elf_file_offset, &error,
+                                &ignored_vm_data, &ignored_vm_instrs,
+                                &isolate_data, &isolate_instrs,
+                                /* load as read-only, not rx */ false);
+      if (leaked_elf != nullptr) {
+        FML_LOG(INFO) << "Loaded ELF";
+      } else {
+        FML_LOG(FATAL) << "Failed to load ELF at " << patch_path
+                       << " error: " << error;
+        abort();
+      }
     }
-  }
 
-  // Look in application specified native library if specified.
-  for (const std::string& path : native_library_path) {
-    auto native_library = fml::NativeLibrary::Create(path.c_str());
-    auto symbol_mapping = std::make_unique<const fml::SymbolMapping>(
-        native_library, native_library_symbol_name);
-    if (symbol_mapping->GetMapping() != nullptr) {
-      return symbol_mapping;
+    FML_LOG(INFO) << "Loading symbol from ELF " << native_library_symbol_name;
+
+    if (native_library_symbol_name == DartSnapshot::kIsolateDataSymbol) {
+      return std::make_unique<const fml::NonOwnedMapping>(isolate_data, 0,
+                                                          nullptr, true);
+    } else if (native_library_symbol_name ==
+               DartSnapshot::kIsolateInstructionsSymbol) {
+      return std::make_unique<const fml::NonOwnedMapping>(isolate_instrs, 0,
+                                                          nullptr, true);
     }
-  }
+    // Fall through to normal lookups for VM data and instructions.
+    // This fallthrough depends on the fact that NativeLibrary below can't
+    // read the ELF out of our .vmcode files.
+  } else {
+    // Only try to open the file if we're not loading a patch.
+#endif
+
+    // Ask the embedder. There is no fallback as we expect the embedders (via
+    // their embedding APIs) to just specify the mappings directly.
+    if (embedder_mapping_callback) {
+      // Note that mapping will be nullptr if the mapping callback returns an
+      // invalid mapping. If all the other methods for resolving the data also
+      // fail, the engine will stop with accompanying error logs.
+      if (auto mapping = embedder_mapping_callback()) {
+        return mapping;
+      }
+    }
+
+    // Attempt to open file at path specified.
+    if (!file_path.empty()) {
+      if (auto file_mapping = GetFileMapping(file_path, is_executable)) {
+        return file_mapping;
+      }
+    }
+
+    // Look in application specified native library if specified.
+    for (const std::string& path : native_library_path) {
+      auto native_library = fml::NativeLibrary::Create(path.c_str());
+      auto symbol_mapping = std::make_unique<const fml::SymbolMapping>(
+          native_library, native_library_symbol_name);
+      if (symbol_mapping->GetMapping() != nullptr) {
+        return symbol_mapping;
+      }
+    }
+
+#if FML_OS_IOS || FML_OS_MACOSX
+  }  // !is_patch
+#endif
 
   // Look inside the currently loaded process.
   {

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -152,6 +152,8 @@ source_set("common") {
     "//flutter/skia",
   ]
 
+  include_dirs = [ "//flutter/updater" ]
+
   if (impeller_supports_rendering) {
     sources += [
       "snapshot_controller_impeller.cc",
@@ -159,6 +161,17 @@ source_set("common") {
     ]
 
     deps += [ "//flutter/impeller" ]
+  }
+
+  # Needed to compile flutter_tester for macOS.
+  if (host_os == "mac" && target_os == "mac") {
+    if (target_cpu == "arm64") {
+      libs = [ "//third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
+    } else if (target_cpu == "x64") {
+      libs = [
+        "//third_party/updater/target/x86_64-apple-darwin/release/libupdater.a",
+      ]
+    }
   }
 }
 

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -43,6 +43,8 @@
 #include "third_party/skia/include/core/SkGraphics.h"
 #include "third_party/tonic/common/log.h"
 
+#include "third_party/updater/library/include/updater.h"
+
 namespace flutter {
 
 constexpr char kSkiaChannel[] = "flutter/skia";
@@ -441,6 +443,14 @@ Shell::Shell(DartVMRef vm,
       is_gpu_disabled_sync_switch_(new fml::SyncSwitch(is_gpu_disabled)),
       weak_factory_gpu_(nullptr),
       weak_factory_(this) {
+  // FIXME: This is probably the wrong place to hook into.
+#if FML_OS_ANDROID || FML_OS_IOS || FML_OS_MACOSX
+  if (!vm_) {
+    shorebird_report_launch_failure();
+  } else {
+    shorebird_report_launch_success();
+  }
+#endif
   FML_CHECK(!settings.enable_software_rendering || !settings.enable_impeller)
       << "Software rendering is incompatible with Impeller.";
   if (!settings.enable_impeller && settings.warn_on_impeller_opt_out) {

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -1,0 +1,56 @@
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
+
+source_set("snapshots_data_handle") {
+  sources = [
+    "snapshots_data_handle.cc",
+    "snapshots_data_handle.h",
+  ]
+
+  deps = [
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
+  ]
+}
+
+source_set("shorebird") {
+  sources = [
+    "shorebird.cc",
+    "shorebird.h",
+  ]
+
+  deps = [
+    ":snapshots_data_handle",
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
+    "//flutter/shell/platform/embedder:embedder_headers",
+  ]
+
+  include_dirs = [ "//flutter/updater" ]
+}
+
+if (enable_unittests) {
+  test_fixtures("shorebird_fixtures") {
+    fixtures = []
+  }
+
+  executable("shorebird_unittests") {
+    testonly = true
+
+    sources = [ "snapshots_data_handle_unittests.cc" ]
+
+    # This only includes snapshots_data_handle and not shorebird because
+    # shorebird fails to link due to a missing updater lib.
+    deps = [
+      ":shorebird_fixtures",
+      ":snapshots_data_handle",
+      "//flutter/runtime",
+      "//flutter/testing",
+      "//flutter/testing:fixture_test",
+    ]
+  }
+}

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -31,6 +31,14 @@ source_set("shorebird") {
   ]
 
   include_dirs = [ "//flutter/updater" ]
+
+  if (host_os == "win" && target_os == "win") {
+    if (target_cpu == "x64") {
+      libs = [
+        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
+      ]
+    }
+  }
 }
 
 if (enable_unittests) {

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -34,9 +34,7 @@ source_set("shorebird") {
 
   if (host_os == "win" && target_os == "win") {
     if (target_cpu == "x64") {
-      libs = [
-        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
-      ]
+      libs = [ "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib" ]
     }
   }
 }

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -1,0 +1,223 @@
+
+#include "flutter/shell/common/shorebird/shorebird.h"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "flutter/fml/command_line.h"
+#include "flutter/fml/file.h"
+#include "flutter/fml/macros.h"
+#include "flutter/fml/mapping.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/native_library.h"
+#include "flutter/fml/paths.h"
+#include "flutter/fml/size.h"
+#include "flutter/lib/ui/plugins/callback_cache.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "flutter/runtime/dart_vm.h"
+#include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+#include "flutter/shell/common/switches.h"
+#include "fml/logging.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+
+#include "third_party/updater/library/include/updater.h"
+
+// Namespaced to avoid Google style warnings.
+namespace flutter {
+
+// Old Android versions (e.g. the v16 ndk Flutter uses) don't always include a
+// getauxval symbol, but the Rust ring crate assumes it exists:
+// https://github.com/briansmith/ring/blob/fa25bf3a7403c9fe6458cb87bd8427be41225ca2/src/cpu/arm.rs#L22
+// It uses it to determine if the CPU supports AES instructions.
+// Making this a weak symbol allows the linker to use a real version instead
+// if it can find one.
+// BoringSSL just reads from procfs instead, which is what we would do if
+// we needed to implement this ourselves.  Implementation looks straightforward:
+// https://lwn.net/Articles/519085/
+// https://github.com/google/boringssl/blob/6ab4f0ae7f2db96d240eb61a5a8b4724e5a09b2f/crypto/cpu_arm_linux.c
+#if defined(__ANDROID__) && defined(__arm__)
+extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
+  return 0;
+}
+#endif
+
+// TODO(eseidel): I believe we need to leak these or we'll sometimes crash
+// when using the base snapshot in mixed mode.  This likely will not play
+// nicely with multi-engine support and will need to be refactored.
+static fml::RefPtr<const DartSnapshot> vm_snapshot;
+static fml::RefPtr<const DartSnapshot> isolate_snapshot;
+
+void SetBaseSnapshot(Settings& settings) {
+  // These mappings happen to be to static data in the App.framework, but
+  // we still need to seem to hold onto the DartSnapshot objects to keep
+  // the mappings alive.
+  vm_snapshot = DartSnapshot::VMSnapshotFromSettings(settings);
+  isolate_snapshot = DartSnapshot::IsolateSnapshotFromSettings(settings);
+  Shorebird_SetBaseSnapshots(isolate_snapshot->GetDataMapping(),
+                             isolate_snapshot->GetInstructionsMapping(),
+                             vm_snapshot->GetDataMapping(),
+                             vm_snapshot->GetInstructionsMapping());
+}
+
+class FileCallbacksImpl {
+ public:
+  static void* Open();
+  static uintptr_t Read(void* file, uint8_t* buffer, uintptr_t length);
+  static int64_t Seek(void* file, int64_t offset, int32_t whence);
+  static void Close(void* file);
+};
+
+FileCallbacks ShorebirdFileCallbacks() {
+  return {
+      .open = FileCallbacksImpl::Open,
+      .read = FileCallbacksImpl::Read,
+      .seek = FileCallbacksImpl::Seek,
+      .close = FileCallbacksImpl::Close,
+  };
+}
+
+void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
+                        flutter::Settings& settings) {
+  // cache_path is used for both code_cache and app_storage, as we don't persist
+  // any data between releases. args.app_path is appended to
+  // the settings.application_library_path vector at this function's call site.
+  ConfigureShorebird(args.cache_path, args.cache_path, settings,
+                     args.shorebird_yaml_contents, args.app_version,
+                     args.app_build_number);
+}
+
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
+                        Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        const std::string& version_code) {
+  // If you are crashing here, you probably are running Shorebird in a Debug
+  // config, where the AOT snapshot won't be linked into the process, and thus
+  // lookups will fail.  Change your Scheme to Release to fix:
+  // https://github.com/flutter/flutter/wiki/Debugging-the-engine#debugging-ios-builds-with-xcode
+  FML_CHECK(DartSnapshot::VMSnapshotFromSettings(settings))
+      << "XCode Scheme must be set to Release to use Shorebird";
+
+  auto shorebird_updater_dir_name = "shorebird_updater";
+
+  auto code_cache_dir = fml::paths::JoinPaths(
+      {std::move(code_cache_path), shorebird_updater_dir_name});
+  auto app_storage_dir = fml::paths::JoinPaths(
+      {std::move(app_storage_path), shorebird_updater_dir_name});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(),
+                       {shorebird_updater_dir_name},
+                       fml::FilePermission::kReadWrite);
+
+  bool init_result;
+  // Using a block to make AppParameters lifetime explicit.
+  {
+    AppParameters app_parameters;
+    // Combine version and version_code into a single string.
+    // We could also pass these separately through to the updater if needed.
+    auto release_version = version + "+" + version_code;
+    app_parameters.release_version = release_version.c_str();
+    app_parameters.code_cache_dir = code_cache_dir.c_str();
+    app_parameters.app_storage_dir = app_storage_dir.c_str();
+
+    // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
+    std::vector<const char*> c_paths{};
+    for (const auto& string : settings.application_library_path) {
+      c_paths.push_back(string.c_str());
+    }
+    // Do not modify application_library_path or c_strings will invalidate.
+
+    app_parameters.original_libapp_paths = c_paths.data();
+    app_parameters.original_libapp_paths_size = c_paths.size();
+
+    // shorebird_init copies from app_parameters and shorebirdYaml.
+    init_result = shorebird_init(&app_parameters, ShorebirdFileCallbacks(),
+                                 shorebird_yaml.c_str());
+  }
+
+  // We've decided not to support synchronous updates on launch for now.
+  // It's a terrible user experience (having the app hang on launch) and
+  // instead we will provide examples of how to build a custom update UI
+  // within Dart, including updating as part of login, etc.
+  // https://github.com/shorebirdtech/shorebird/issues/950
+
+  // We only set the base snapshot on iOS for now.
+#if FML_OS_IOS || FML_OS_MACOSX
+  SetBaseSnapshot(settings);
+#endif
+
+  char* c_active_path = shorebird_next_boot_patch_path();
+  if (c_active_path != NULL) {
+    std::string active_path = c_active_path;
+    shorebird_free_string(c_active_path);
+    FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
+
+#if FML_OS_IOS || FML_OS_MACOSX
+    // On iOS we add the patch to the front of the list instead of clearing
+    // the list, to allow dart_shapshot.cc to still find the base snapshot
+    // for the vm isolate.
+    settings.application_library_path.insert(
+        settings.application_library_path.begin(), active_path);
+#else
+    settings.application_library_path.clear();
+    settings.application_library_path.emplace_back(active_path);
+#endif
+  } else {
+    FML_LOG(INFO) << "Shorebird updater: no active patch.";
+  }
+
+  // We are careful only to report a launch start in the case where it's the
+  // first time we've configured shorebird this process. Otherwise we could end
+  // up in a case where we report a launch start, but never a completion (e.g.
+  // from package:flutter_work_manager which sometimes creates a FlutterEngine
+  // (and thus configures shorebird) but never runs it. The proper fix for this
+  // is probably to move the launch_start() call to be later in the lifecycle
+  // (when the snapshot is loaded and run, rather than when FlutterEngine is
+  // initialized).  This "hack" will still have a problem where FlutterEngine is
+  // initialized but never run before the app is quit, could still cause us to
+  // suddenly mark-bad a patch that was never actually attempted to launch.
+  if (!init_result) {
+    return;
+  }
+
+  // Once start_update_thread is called, the next_boot_patch* functions may
+  // change their return values if the shorebird_report_launch_failed
+  // function is called.
+  shorebird_report_launch_start();
+
+  if (shorebird_should_auto_update()) {
+    FML_LOG(INFO) << "Starting Shorebird update";
+    shorebird_start_update_thread();
+  } else {
+    FML_LOG(INFO)
+        << "Shorebird auto_update disabled, not checking for updates.";
+  }
+}
+
+void* FileCallbacksImpl::Open() {
+  return SnapshotsDataHandle::createForSnapshots(*vm_snapshot,
+                                                 *isolate_snapshot)
+      .release();
+}
+
+uintptr_t FileCallbacksImpl::Read(void* file,
+                                  uint8_t* buffer,
+                                  uintptr_t length) {
+  return reinterpret_cast<SnapshotsDataHandle*>(file)->Read(buffer, length);
+}
+
+int64_t FileCallbacksImpl::Seek(void* file, int64_t offset, int32_t whence) {
+  // Currently we only support blob handles.
+  return reinterpret_cast<SnapshotsDataHandle*>(file)->Seek(offset, whence);
+}
+
+void FileCallbacksImpl::Close(void* file) {
+  delete reinterpret_cast<SnapshotsDataHandle*>(file);
+}
+
+}  // namespace flutter

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -14,7 +14,6 @@
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/native_library.h"
 #include "flutter/fml/paths.h"
-#include "flutter/fml/size.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_snapshot.h"
 #include "flutter/runtime/dart_vm.h"

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_
+#define FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_
+
+#include "flutter/common/settings.h"
+#include "shell/platform/embedder/embedder.h"
+
+namespace flutter {
+
+void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
+                        flutter::Settings& settings);
+
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
+                        flutter::Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        const std::string& version_code);
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_

--- a/shell/common/shorebird/snapshots_data_handle.cc
+++ b/shell/common/shorebird/snapshots_data_handle.cc
@@ -1,0 +1,144 @@
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+
+#include "third_party/dart/runtime/include/dart_native_api.h"
+
+namespace flutter {
+
+static std::unique_ptr<fml::Mapping> DataMapping(const DartSnapshot& snapshot) {
+  auto ptr = snapshot.GetDataMapping();
+  return std::make_unique<fml::NonOwnedMapping>(ptr,
+                                                Dart_SnapshotDataSize(ptr));
+}
+
+static std::unique_ptr<fml::Mapping> InstructionsMapping(
+    const DartSnapshot& snapshot) {
+  auto ptr = snapshot.GetInstructionsMapping();
+  return std::make_unique<fml::NonOwnedMapping>(ptr,
+                                                Dart_SnapshotInstrSize(ptr));
+}
+
+// The size of the snapshot data is the sum of the sizes of the blobs.
+size_t SnapshotsDataHandle::FullSize() const {
+  size_t size = 0;
+  for (const auto& blob : blobs_) {
+    size += blob->GetSize();
+  }
+  return size;
+}
+
+// The offset into the snapshots data blobs as though they were a single
+// contiguous buffer.
+size_t SnapshotsDataHandle::AbsoluteOffsetForIndex(BlobsIndex index) {
+  if (index.blob >= blobs_.size()) {
+    FML_LOG(WARNING) << "Blob index " << index.blob
+                     << " is larger than the number of blobs (" << blobs_.size()
+                     << "). Returning full size (" << FullSize() << ")";
+    return FullSize();
+  }
+  if (index.offset > blobs_[index.blob]->GetSize()) {
+    FML_LOG(WARNING) << "Offset for blob " << index.blob << " (" << index.offset
+                     << ") is larger than the blob size ("
+                     << blobs_[index.blob]->GetSize()
+                     << "). Returning index start of next blob";
+    return AbsoluteOffsetForIndex({index.blob + 1, 0});
+  }
+  size_t offset = 0;
+  for (size_t i = 0; i < index.blob; i++) {
+    offset += blobs_[i]->GetSize();
+  }
+  offset += index.offset;
+  return offset;
+}
+
+BlobsIndex SnapshotsDataHandle::IndexForAbsoluteOffset(int64_t offset,
+                                                       BlobsIndex start_index) {
+  size_t start_offset = AbsoluteOffsetForIndex(start_index);
+  if (offset < 0) {
+    if ((size_t)abs(offset) > start_offset) {
+      FML_LOG(WARNING)
+          << "Offset is before the beginning of SnapshotsData. Returning 0, 0";
+      return {0, 0};
+    }
+  } else if (offset + start_offset >= FullSize()) {
+    FML_LOG(WARNING) << "Target offset is past the end of SnapshotsData ("
+                     << offset + start_offset << ", blobs size:" << FullSize()
+                     << "). Returning last blob index and offset";
+    return {blobs_.size(), blobs_.back()->GetSize()};
+  }
+
+  size_t dest_offset = start_offset + offset;
+  BlobsIndex index = {0, 0};
+  for (const auto& blob : blobs_) {
+    if (dest_offset < blob->GetSize()) {
+      // The remaining offset is within this blob.
+      index.offset = dest_offset;
+      break;
+    }
+
+    index.blob++;
+    dest_offset -= blob->GetSize();
+  }
+  return index;
+}
+
+std::unique_ptr<SnapshotsDataHandle> SnapshotsDataHandle::createForSnapshots(
+    const DartSnapshot& vm_snapshot,
+    const DartSnapshot& isolate_snapshot) {
+  // This needs to match the order in which the blobs are written out in
+  // analyze_snapshot --dump_blobs
+  std::vector<std::unique_ptr<fml::Mapping>> blobs;
+  blobs.push_back(DataMapping(vm_snapshot));
+  blobs.push_back(DataMapping(isolate_snapshot));
+  blobs.push_back(InstructionsMapping(vm_snapshot));
+  blobs.push_back(InstructionsMapping(isolate_snapshot));
+  return std::make_unique<SnapshotsDataHandle>(std::move(blobs));
+}
+
+uintptr_t SnapshotsDataHandle::Read(uint8_t* buffer, uintptr_t length) {
+  uintptr_t bytes_read = 0;
+  // Copy current blob from current offset and possibly into the next blob
+  // until we have read length bytes.
+  while (bytes_read < length) {
+    if (current_index_.blob >= blobs_.size()) {
+      // We have read all blobs.
+      break;
+    }
+    intptr_t remaining_blob_length =
+        blobs_[current_index_.blob]->GetSize() - current_index_.offset;
+    if (remaining_blob_length <= 0) {
+      // We have read all bytes in this blob.
+      current_index_.blob++;
+      current_index_.offset = 0;
+      continue;
+    }
+    intptr_t bytes_to_read = fmin(length - bytes_read, remaining_blob_length);
+    memcpy(buffer + bytes_read,
+           blobs_[current_index_.blob]->GetMapping() + current_index_.offset,
+           bytes_to_read);
+    bytes_read += bytes_to_read;
+    current_index_.offset += bytes_to_read;
+  }
+
+  return bytes_read;
+}
+
+int64_t SnapshotsDataHandle::Seek(int64_t offset, int32_t whence) {
+  BlobsIndex start_index;
+  switch (whence) {
+    case SEEK_CUR:
+      start_index = current_index_;
+      break;
+    case SEEK_SET:
+      start_index = {0, 0};
+      break;
+    case SEEK_END:
+      start_index = {blobs_.size(), blobs_.back()->GetSize()};
+      break;
+    default:
+      FML_CHECK(false) << "Unrecognized whence value in Seek: " << whence;
+  }
+  current_index_ = IndexForAbsoluteOffset(offset, start_index);
+  return current_index_.offset;
+}
+
+}  // namespace flutter

--- a/shell/common/shorebird/snapshots_data_handle.h
+++ b/shell/common/shorebird/snapshots_data_handle.h
@@ -1,0 +1,47 @@
+#ifndef FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_
+#define FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_
+
+#include "flutter/fml/file.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+
+namespace flutter {
+
+// An offset into an indexed collection of buffers. blob is the index of the
+// buffer, and offset is the offset into that buffer.
+struct BlobsIndex {
+  size_t blob;
+  size_t offset;
+};
+
+// Implements a POSIX file I/O interface which allows us to provide the four
+// data blobs of a Dart snapshot (vm_data, vm_instructions, isolate_data,
+// isolate_instructions) to Rust as though it were a single piece of memory.
+class SnapshotsDataHandle {
+ public:
+  // This would ideally be private, but we need to be able to call it from the
+  // static createForSnapshots method.
+  explicit SnapshotsDataHandle(std::vector<std::unique_ptr<fml::Mapping>> blobs)
+      : blobs_(std::move(blobs)) {}
+
+  static std::unique_ptr<SnapshotsDataHandle> createForSnapshots(
+      const DartSnapshot& vm_snapshot,
+      const DartSnapshot& isolate_snapshot);
+
+  uintptr_t Read(uint8_t* buffer, uintptr_t length);
+  int64_t Seek(int64_t offset, int32_t whence);
+
+  // The sum of all the blobs' sizes.
+  size_t FullSize() const;
+
+ private:
+  size_t AbsoluteOffsetForIndex(BlobsIndex index);
+  BlobsIndex IndexForAbsoluteOffset(int64_t offset, BlobsIndex startIndex);
+
+  BlobsIndex current_index_ = {0, 0};
+  std::vector<std::unique_ptr<fml::Mapping>> blobs_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_

--- a/shell/common/shorebird/snapshots_data_handle_unittests.cc
+++ b/shell/common/shorebird/snapshots_data_handle_unittests.cc
@@ -1,0 +1,177 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+
+#include "flutter/fml/mapping.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "testing/fixture_test.h"
+
+namespace flutter {
+namespace testing {
+
+std::unique_ptr<SnapshotsDataHandle> MakeHandle(
+    std::vector<std::string>& blobs) {
+  // Map the strings into non-owned mappings:
+  std::vector<std::unique_ptr<fml::Mapping>> mappings = {};
+  for (auto& blob : blobs) {
+    std::unique_ptr<fml::Mapping> mapping =
+        std::make_unique<fml::NonOwnedMapping>(
+            reinterpret_cast<const uint8_t*>(blob.data()), blob.size());
+    mappings.push_back(std::move(mapping));
+  }
+  auto handle =
+      std::make_unique<flutter::SnapshotsDataHandle>(std::move(mappings));
+  return handle;
+}
+
+TEST(SnapshotsDataHandle, Read) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 12;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+  EXPECT_EQ(buffer[2], 'c');
+  EXPECT_EQ(buffer[3], 'd');
+  EXPECT_EQ(buffer[4], 'e');
+  EXPECT_EQ(buffer[5], 'f');
+
+  // Only the first 6 bytes should have been read.
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, ReadAfterSeekWithPositiveOffset) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  blobs_handle->Seek(4, SEEK_CUR);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'e');
+  EXPECT_EQ(buffer[1], 'f');
+  EXPECT_EQ(buffer[2], 'g');
+  EXPECT_EQ(buffer[3], 'h');
+  EXPECT_EQ(buffer[4], 'i');
+  EXPECT_EQ(buffer[5], 'j');
+
+  // Only the first 6 bytes should have been read.
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, ReadAfterSeekWithNegativeOffset) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  blobs_handle->Read(buffer, 5);
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+  EXPECT_EQ(buffer[2], 'c');
+  EXPECT_EQ(buffer[3], 'd');
+  EXPECT_EQ(buffer[4], 'e');
+  EXPECT_EQ(buffer[5], 0);
+
+  // Reset buffer
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Read 5, seeked back 4, should start reading at offset 1 ('b')
+  blobs_handle->Seek(-4, SEEK_CUR);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'b');
+  EXPECT_EQ(buffer[1], 'c');
+  EXPECT_EQ(buffer[2], 'd');
+  EXPECT_EQ(buffer[3], 'e');
+  EXPECT_EQ(buffer[4], 'f');
+  EXPECT_EQ(buffer[5], 'g');
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, SeekPastEnd) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 1 past the end
+  blobs_handle->Seek(blobs_handle->FullSize() + 1, SEEK_CUR);
+
+  // Seek back 2 bytes and read 2 bytes
+  blobs_handle->Seek(-2, SEEK_CUR);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'k');
+  EXPECT_EQ(buffer[1], 'l');
+}
+
+TEST(SnapshotsDataHandle, SeekBeforeBeginning) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek before the start of the blobs and read the first 2 bytes.
+  blobs_handle->Seek(-2, SEEK_CUR);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+}
+
+TEST(SnapshotsDataHandle, SeekFromBeginning) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 10 bytes from current (the beginning)
+  blobs_handle->Seek(10, SEEK_CUR);
+
+  // Seek 2 bytes from the beginning and read 2 bytes
+  blobs_handle->Seek(2, SEEK_SET);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'c');
+  EXPECT_EQ(buffer[1], 'd');
+}
+
+TEST(SnapshotsDataHandle, SeekFromEnd) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 2 bytes from the end and read 2 bytes
+  blobs_handle->Seek(-2, SEEK_END);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'k');
+  EXPECT_EQ(buffer[1], 'l');
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -159,6 +159,7 @@ source_set("flutter_shell_native_src") {
     "//flutter/runtime",
     "//flutter/runtime:libdart",
     "//flutter/shell/common",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/android/context",
     "//flutter/shell/platform/android/external_view_embedder",
     "//flutter/shell/platform/android/jni",
@@ -172,6 +173,8 @@ source_set("flutter_shell_native_src") {
 
   public_configs = [ "//flutter:config" ]
 
+  include_dirs = [ "//flutter/updater" ]
+
   defines = []
 
   libs = [
@@ -179,6 +182,23 @@ source_set("flutter_shell_native_src") {
     "EGL",
     "GLESv2",
   ]
+  if (target_cpu == "arm") {
+    libs += [ "//third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
+  } else if (target_cpu == "arm64") {
+    libs += [
+      "//third_party/updater/target/aarch64-linux-android/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x64") {
+    libs += [
+      "//third_party/updater/target/x86_64-linux-android/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x86") {
+    libs += [
+      "//third_party/updater/target/i686-linux-android/release/libupdater.a",
+    ]
+  } else {
+    assert(false, "Unsupported target_cpu")
+  }
 }
 
 action("gen_android_build_config_java") {
@@ -726,12 +746,23 @@ if (target_cpu != "x86") {
 
   # TODO(godofredoc): Remove gen_snapshot and rename new_gen_snapshot when v2 migration is complete.
   # BUG: https://github.com/flutter/flutter/issues/105351
+  # This has a somewhat misleading name. We (shorebird) have updated this target
+  # to include analyze_snapshot as well as gen_snapshot. Because this target is
+  # used elsewhere in the toolchain, we did not rename it.
   zip_bundle("new_gen_snapshot") {
     gen_snapshot_bin = "gen_snapshot"
     gen_snapshot_out_dir =
         get_label_info("$dart_src/runtime/bin:gen_snapshot($host_toolchain)",
                        "root_out_dir")
     gen_snapshot_path = rebase_path("$gen_snapshot_out_dir/$gen_snapshot_bin")
+
+    analyze_snapshot_bin = "analyze_snapshot"
+    analyze_snapshot_out_dir =
+        get_label_info(
+            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+    analyze_snapshot_path =
+        rebase_path("$analyze_snapshot_out_dir/$analyze_snapshot_bin")
 
     if (host_os == "linux") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/linux-x64.zip"
@@ -741,6 +772,8 @@ if (target_cpu != "x86") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/windows-x64.zip"
       gen_snapshot_bin = "gen_snapshot.exe"
       gen_snapshot_path = rebase_path("$root_out_dir/$gen_snapshot_bin")
+      analyze_snapshot_bin = "analyze_snapshot.exe"
+      analyze_snapshot_path = rebase_path("$root_out_dir/$analyze_snapshot_bin")
     }
 
     files = [
@@ -748,9 +781,16 @@ if (target_cpu != "x86") {
         source = gen_snapshot_path
         destination = gen_snapshot_bin
       },
+      {
+        source = analyze_snapshot_path
+        destination = analyze_snapshot_bin
+      },
     ]
 
-    deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    deps = [
+      "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+      "$dart_src/runtime/bin:gen_snapshot($host_toolchain)",
+    ]
 
     if (host_os == "mac") {
       deps += [ ":android_entitlement_config" ]
@@ -764,7 +804,7 @@ if (target_cpu != "x86") {
   }
 }
 
-if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+if (target_cpu == "arm64") {
   zip_bundle("analyze_snapshot") {
     deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
 

--- a/shell/platform/android/android_exports.lst
+++ b/shell/platform/android/android_exports.lst
@@ -11,6 +11,16 @@
     _binary_icudtl_dat_size;
     InternalFlutterGpu*;
     kInternalFlutterGpu*;
+    shorebird_init;
+    shorebird_active_path;
+    shorebird_active_patch_number;
+    shorebird_free_string;
+    shorebird_free_update_result;
+    shorebird_check_for_downloadable_update;
+    shorebird_update;
+    shorebird_update_with_result;
+    shorebird_next_boot_patch_number;
+    shorebird_current_boot_patch_number;
   local:
     *;
 };

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -21,6 +21,7 @@
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
 #include "flutter/shell/platform/android/context/android_context.h"
@@ -29,6 +30,8 @@
 #include "impeller/toolkit/android/proc_table.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "txt/platform.h"
+
+#include "third_party/updater/library/include/updater.h"
 
 namespace flutter {
 
@@ -72,6 +75,9 @@ void FlutterMain::Init(JNIEnv* env,
                        jstring kernelPath,
                        jstring appStoragePath,
                        jstring engineCachesPath,
+                       jstring shorebirdYaml,
+                       jstring version,
+                       jstring versionCode,
                        jlong initTimeMillis) {
   std::vector<std::string> args;
   args.push_back("flutter");
@@ -120,8 +126,18 @@ void FlutterMain::Init(JNIEnv* env,
   flutter::DartCallbackCache::SetCachePath(
       fml::jni::JavaStringToString(env, appStoragePath));
 
-  fml::paths::InitializeAndroidCachesPath(
-      fml::jni::JavaStringToString(env, engineCachesPath));
+  auto code_cache_path = fml::jni::JavaStringToString(env, engineCachesPath);
+  auto app_storage_path = fml::jni::JavaStringToString(env, appStoragePath);
+  fml::paths::InitializeAndroidCachesPath(code_cache_path);
+
+#if FLUTTER_RELEASE
+  std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
+  std::string version_string = fml::jni::JavaStringToString(env, version);
+  std::string version_code_string =
+      fml::jni::JavaStringToString(env, versionCode);
+  ConfigureShorebird(code_cache_path, app_storage_path, settings,
+                     shorebird_yaml, version_string, version_code_string);
+#endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();
 
@@ -211,6 +227,7 @@ bool FlutterMain::Register(JNIEnv* env) {
       {
           .name = "nativeInit",
           .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
+                       "lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/"
                        "lang/String;Ljava/lang/String;Ljava/lang/String;J)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -39,6 +39,9 @@ class FlutterMain {
                    jstring kernelPath,
                    jstring appStoragePath,
                    jstring engineCachesPath,
+                   jstring shorebirdYaml,
+                   jstring version,
+                   jstring versionCode,
                    jlong initTimeMillis);
 
   void SetupDartVMServiceUriCallback(JNIEnv* env);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -7,6 +7,8 @@ package io.flutter.embedding.engine;
 import static io.flutter.Build.API_LEVELS;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -40,7 +42,10 @@ import io.flutter.util.Preconditions;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.FlutterCallbackInformation;
 import io.flutter.view.TextureRegistry;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -177,6 +182,9 @@ public class FlutterJNI {
       @Nullable String bundlePath,
       @NonNull String appStoragePath,
       @NonNull String engineCachesPath,
+      @Nullable String shorebirdYaml,
+      @Nullable String version,
+      @Nullable String versionCode,
       long initTimeMillis);
 
   /**
@@ -202,8 +210,46 @@ public class FlutterJNI {
       Log.w(TAG, "FlutterJNI.init called more than once");
     }
 
+    String version = null;
+    String versionCode = null;
+    try {
+      PackageInfo packageInfo =
+          context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      version = packageInfo.versionName;
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_28) {
+        versionCode = String.valueOf(packageInfo.getLongVersionCode());
+      } else {
+        versionCode = String.valueOf(packageInfo.versionCode);
+      }
+    } catch (PackageManager.NameNotFoundException e) {
+      Log.e(TAG, "Failed to read app version.  Shorebird updater can't run.", e);
+    }
+
+    String shorebirdYaml = null;
+    try {
+      InputStream yaml = context.getAssets().open("flutter_assets/shorebird.yaml");
+      BufferedReader r = new BufferedReader(new InputStreamReader(yaml));
+      StringBuilder total = new StringBuilder();
+      for (String line; (line = r.readLine()) != null; ) {
+        total.append(line).append('\n');
+      }
+      shorebirdYaml = total.toString();
+      Log.d(TAG, "shorebird.yaml: " + shorebirdYaml);
+    } catch (IOException e) {
+      Log.e(TAG, "Failed to load shorebird.yaml", e);
+      Log.e(TAG, "Did you remember to include shorebird.yaml in your pubspec.yaml's assets?");
+    }
+
     FlutterJNI.nativeInit(
-        context, args, bundlePath, appStoragePath, engineCachesPath, initTimeMillis);
+        context,
+        args,
+        bundlePath,
+        appStoragePath,
+        engineCachesPath,
+        shorebirdYaml,
+        version,
+        versionCode,
+        initTimeMillis);
     FlutterJNI.initCalled = true;
   }
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -52,6 +52,7 @@ source_set("flutter_framework_source_arc") {
   deps = [
     ":flutter_framework_source",
     "//flutter/fml",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/third_party/icu",
@@ -202,9 +203,11 @@ source_set("flutter_framework_source") {
   }
 
   deps += [
+    "$dart_src/runtime/bin:elf_loader",
     "//flutter/fml",
     "//flutter/runtime",
     "//flutter/shell/common",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
@@ -216,6 +219,17 @@ source_set("flutter_framework_source") {
     ":ios_gpu_configuration_config",
     "//flutter:config",
   ]
+
+  if (target_cpu == "arm64") {
+    libs = [
+      "//third_party/updater/target/aarch64-apple-ios/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x64") {
+    libs =
+        [ "//third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
+  } else {
+    assert(false, "Unsupported target_cpu")
+  }
 
   frameworks = [
     "AudioToolbox.framework",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -12,6 +12,8 @@
 #include <syslog.h>
 
 #include "flutter/common/constants.h"
+#include "flutter/fml/paths.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
 
@@ -96,10 +98,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   }
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
+    NSLog(@"SANITY CHECK: Running precompiled code.");
     if (hasExplicitBundle) {
       NSString* executablePath = bundle.executablePath;
       if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
         settings.application_library_path.push_back(executablePath.UTF8String);
+        NSLog(@"Using precompiled library from %@", executablePath);
       }
     }
 
@@ -111,6 +115,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         NSString* executablePath = [NSBundle bundleWithPath:libraryPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using library from %@", libraryPath);
         }
       }
     }
@@ -125,6 +130,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
             [NSBundle bundleWithPath:applicationFrameworkPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using App.framework from %@", applicationFrameworkPath);
         }
       }
     }
@@ -154,6 +160,33 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         }
       }
     }
+  }
+
+  NSString* assetsPath = [NSString stringWithUTF8String:settings.assets_path.c_str()];
+  NSLog(@"ASSET PATH %@", assetsPath);
+
+  // FIXME: This may not be the correct path (e.g., should it include the organization id?)
+  // See
+  // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW13
+  // /private/var/mobile/Containers/Data/Application/264477BF-6E38-47C9-AAD9-532BB842F197/Library/Application
+  // Support/shorebird/shorebird_updater
+  std::string cache_path =
+      fml::paths::JoinPaths({getenv("HOME"), "Library/Application Support/shorebird"});
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* appVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  if (shorebirdYamlContents != nil) {
+    // Note: we intentionally pass cache_path twice. We provide two different directories
+    //   to ConfigureShorebird because Android differentiates between data that persists
+    //   between releases and data that does not. iOS does not make this distinction.
+    flutter::ConfigureShorebird(cache_path, cache_path, settings, shorebirdYamlContents.UTF8String,
+                                appVersion.UTF8String, appBuildNumber.UTF8String);
+  } else {
+    NSLog(@"Failed to find shorebird.yaml, not starting updater.");
   }
 
   // Domain network configuration

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -34,6 +34,8 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
+#import <third_party/dart/runtime/vm/cpu.h>
+
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
@@ -238,6 +240,8 @@ typedef struct MouseState {
   if (!project) {
     project = [[[FlutterDartProject alloc] init] autorelease];
   }
+  FML_LOG(INFO) << "CPU::Id(): " << dart::CPU::Id();
+
   FlutterView.forceSoftwareRendering = project.settings.enable_software_rendering;
   _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
   auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -127,6 +127,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
+    "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:availability_version_check",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics:graphics",

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "flutter/common/constants.h"
+#include "flutter/fml/paths.h"
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -678,6 +679,28 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
     [engine onVSync:baton];
   };
+
+  NSString* bundlePath =
+      [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                   URLByAppendingPathComponent:@"App.framework"]] bundlePath];
+  bundlePath = [bundlePath stringByAppendingString:@"/App"];
+  flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
+  NSString* assetsPath = _project.assetsPath;
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  NSString* appVersion =
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
+  flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
+
+  std::string cache_path =
+      fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
+  flutterArguments.shorebird_args.cache_path = cache_path.c_str();
+  flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
   FlutterEngineResult result = _embedderAPI.Initialize(

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -110,6 +110,7 @@ template("embedder_source_set") {
       "//flutter/lib/ui",
       "//flutter/runtime:libdart",
       "//flutter/shell/common",
+      "//flutter/shell/common/shorebird",
       "//flutter/skia",
       "//flutter/third_party/tonic",
     ]

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -50,6 +50,7 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/rasterizer.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_engine.h"
@@ -2304,6 +2305,15 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         kInvalidArguments,
         "Could not infer the Flutter project to run from given arguments.");
   }
+
+  // Begin shorebird
+  if (args->shorebird_args.shorebird_yaml_contents) {
+    settings.application_library_path.push_back(args->shorebird_args.app_path);
+    flutter::ConfigureShorebird(args->shorebird_args, settings);
+  } else {
+    FML_LOG(INFO) << "[shorebird] No shorebird YAML contents provided.";
+  }
+  // End shorebird
 
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2205,6 +2205,42 @@ typedef void (*FlutterLogMessageCallback)(const char* /* tag */,
 typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
 
 typedef struct {
+  /// The version of the app (e.g., 1.0.0).
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_version;
+
+  /// The build number of the app (e.g., 1).
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_build_number;
+
+  /// The text contents of the shorebird.yaml file bundled with the compiled
+  /// app. Note that this is _not_ the same as the shorebird.yaml that exists in
+  /// the user's project.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* shorebird_yaml_contents;
+
+  /// The path to the directory where Shorebird will store patches and state
+  /// data.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* cache_path;
+
+  /// The path to the executable file. This is a Mach-O executable file on
+  /// macOS.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_path;
+} ShorebirdFlutterProjectArgs;
+
+typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
   /// The path to the Flutter assets directory containing project assets. The
@@ -2503,6 +2539,9 @@ typedef struct {
   /// being registered on the framework side. The callback is invoked from
   /// a task posted to the platform thread.
   FlutterChannelUpdateCallback channel_update_callback;
+
+  /// Data used to initialize Shorebird as part of engine initialization.
+  ShorebirdFlutterProjectArgs shorebird_args;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -60,7 +60,7 @@ class ScopedGlobalMemory {
     memory_ = ::GlobalAlloc(flags, bytes);
     if (!memory_) {
       FML_LOG(ERROR) << "Unable to allocate global memory: "
-                     << ::GetLastError();
+                     << static_cast<int>(::GetLastError());
     }
   }
 
@@ -68,7 +68,7 @@ class ScopedGlobalMemory {
     if (memory_) {
       if (::GlobalFree(memory_) != nullptr) {
         FML_LOG(ERROR) << "Failed to free global allocation: "
-                       << ::GetLastError();
+                       << static_cast<int>(::GetLastError());
       }
     }
   }
@@ -175,12 +175,12 @@ std::variant<std::wstring, int> ScopedClipboard::GetString() {
 
   HANDLE data = ::GetClipboardData(CF_UNICODETEXT);
   if (data == nullptr) {
-    return ::GetLastError();
+    return static_cast<int>(::GetLastError());
   }
   ScopedGlobalLock locked_data(data);
 
   if (!locked_data.get()) {
-    return ::GetLastError();
+    return static_cast<int>(::GetLastError());
   }
   return static_cast<wchar_t*>(locked_data.get());
 }

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -38,6 +38,7 @@ executable("testing") {
   deps = [
     "$dart_src/runtime:libdart_jit",
     "$dart_src/runtime/bin:dart_io_api",
+    "$dart_src/runtime/bin:elf_loader",
     "//flutter/assets",
     "//flutter/common",
     "//flutter/flow",

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Generates and zip the ios flutter framework including the architecture
+# dependent snapshot.
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+from create_xcframework import create_xcframework  # pylint: disable=import-error
+
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
+DSYMUTIL = os.path.join(
+    os.path.dirname(__file__), '..', '..', 'buildtools', ARCH_SUBPATH, 'clang', 'bin', 'dsymutil'
+)
+
+buildroot_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..', '..', '..', '..'))
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description=(
+          'Creates Flutter.framework, Flutter.xcframework and '
+          'copies architecture-dependent gen_snapshot binaries to output dir'
+      )
+  )
+
+  parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--clang-dir', type=str, default='clang_x64')
+  parser.add_argument('--x64-out-dir', type=str)
+  parser.add_argument('--arm64-out-dir', type=str, required=True)
+  parser.add_argument('--simulator-x64-out-dir', type=str, required=True)
+  parser.add_argument('--simulator-arm64-out-dir', type=str, required=False)
+  parser.add_argument('--strip', action='store_true', default=False)
+  parser.add_argument('--dsym', action='store_true', default=False)
+
+  args = parser.parse_args()
+
+  dst = (args.dst if os.path.isabs(args.dst) else os.path.join(buildroot_dir, args.dst))
+
+  arm64_out_dir = (
+      args.arm64_out_dir
+      if os.path.isabs(args.arm64_out_dir) else os.path.join(buildroot_dir, args.arm64_out_dir)
+  )
+
+  x64_out_dir = None
+  if args.x64_out_dir:
+    x64_out_dir = (
+        args.x64_out_dir
+        if os.path.isabs(args.x64_out_dir) else os.path.join(buildroot_dir, args.x64_out_dir)
+    )
+
+  simulator_x64_out_dir = None
+  if args.simulator_x64_out_dir:
+    simulator_x64_out_dir = (
+        args.simulator_x64_out_dir if os.path.isabs(args.simulator_x64_out_dir) else
+        os.path.join(buildroot_dir, args.simulator_x64_out_dir)
+    )
+
+  framework = os.path.join(dst, 'Flutter.framework')
+  simulator_framework = os.path.join(dst, 'sim', 'Flutter.framework')
+  arm64_framework = os.path.join(arm64_out_dir, 'Flutter.framework')
+  simulator_x64_framework = os.path.join(simulator_x64_out_dir, 'Flutter.framework')
+
+  simulator_arm64_out_dir = None
+  if args.simulator_arm64_out_dir:
+    simulator_arm64_out_dir = (
+        args.simulator_arm64_out_dir if os.path.isabs(args.simulator_arm64_out_dir) else
+        os.path.join(buildroot_dir, args.simulator_arm64_out_dir)
+    )
+
+  if args.simulator_arm64_out_dir is not None:
+    simulator_arm64_framework = os.path.join(simulator_arm64_out_dir, 'Flutter.framework')
+
+  if not os.path.isdir(arm64_framework):
+    print('Cannot find iOS arm64 Framework at %s' % arm64_framework)
+    return 1
+
+  if not os.path.isdir(simulator_x64_framework):
+    print('Cannot find iOS x64 simulator Framework at %s' % simulator_framework)
+    return 1
+
+  if not os.path.isfile(DSYMUTIL):
+    print('Cannot find dsymutil at %s' % DSYMUTIL)
+    return 1
+
+  create_framework(
+      args, dst, framework, arm64_framework, simulator_framework, simulator_x64_framework,
+      simulator_arm64_framework
+  )
+
+  extension_safe_dst = os.path.join(dst, 'extension_safe')
+  create_extension_safe_framework(
+      args, extension_safe_dst, '%s_extension_safe' % arm64_out_dir,
+      '%s_extension_safe' % simulator_x64_out_dir, '%s_extension_safe' % simulator_arm64_out_dir
+  )
+
+  generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  generate_analyze_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  zip_archive(dst)
+  return 0
+
+def create_extension_safe_framework( # pylint: disable=too-many-arguments
+    args, dst, arm64_out_dir, simulator_x64_out_dir, simulator_arm64_out_dir
+):
+  framework = os.path.join(dst, 'Flutter.framework')
+  simulator_framework = os.path.join(dst, 'sim', 'Flutter.framework')
+  arm64_framework = os.path.join(arm64_out_dir, 'Flutter.framework')
+  simulator_x64_framework = os.path.join(simulator_x64_out_dir, 'Flutter.framework')
+  simulator_arm64_framework = os.path.join(simulator_arm64_out_dir, 'Flutter.framework')
+
+  if not os.path.isdir(arm64_framework):
+    print('Cannot find extension safe iOS arm64 Framework at %s' % arm64_framework)
+    return 1
+
+  if not os.path.isdir(simulator_x64_framework):
+    print('Cannot find extension safe iOS x64 simulator Framework at %s' % simulator_x64_framework)
+    return 1
+
+  create_framework(
+      args, dst, framework, arm64_framework, simulator_framework, simulator_x64_framework,
+      simulator_arm64_framework
+  )
+  return 0
+
+def create_framework(  # pylint: disable=too-many-arguments
+    args, dst, framework, arm64_framework, simulator_framework,
+    simulator_x64_framework, simulator_arm64_framework
+):
+  arm64_dylib = os.path.join(arm64_framework, 'Flutter')
+  simulator_x64_dylib = os.path.join(simulator_x64_framework, 'Flutter')
+  simulator_arm64_dylib = os.path.join(simulator_arm64_framework, 'Flutter')
+  if not os.path.isfile(arm64_dylib):
+    print('Cannot find iOS arm64 dylib at %s' % arm64_dylib)
+    return 1
+
+  if not os.path.isfile(simulator_x64_dylib):
+    print('Cannot find iOS simulator dylib at %s' % simulator_x64_dylib)
+    return 1
+
+  # Compute dsym output paths, if enabled.
+  framework_dsym = None
+  simulator_dsym = None
+  if args.dsym:
+    framework_dsym = framework + '.dSYM'
+    simulator_dsym = simulator_framework + '.dSYM'
+
+  # Emit the framework for physical devices.
+  shutil.rmtree(framework, True)
+  shutil.copytree(arm64_framework, framework)
+  framework_binary = os.path.join(framework, 'Flutter')
+  process_framework(args, dst, framework_binary, framework_dsym)
+
+  # Emit the framework for simulators.
+  if args.simulator_arm64_out_dir is not None:
+    shutil.rmtree(simulator_framework, True)
+    shutil.copytree(simulator_arm64_framework, simulator_framework)
+
+    simulator_framework_binary = os.path.join(simulator_framework, 'Flutter')
+
+    # Create the arm64/x64 simulator fat framework.
+    subprocess.check_call([
+        'lipo', simulator_x64_dylib, simulator_arm64_dylib, '-create', '-output',
+        simulator_framework_binary
+    ])
+    process_framework(args, dst, simulator_framework_binary, simulator_dsym)
+  else:
+    simulator_framework = simulator_x64_framework
+
+  # Create XCFramework from the arm-only fat framework and the arm64/x64
+  # simulator frameworks, or just the x64 simulator framework if only that one
+  # exists.
+  xcframeworks = [simulator_framework, framework]
+  dsyms = [simulator_dsym, framework_dsym] if args.dsym else None
+  create_xcframework(location=dst, name='Flutter', frameworks=xcframeworks, dsyms=dsyms)
+
+  # Add the x64 simulator into the fat framework.
+  subprocess.check_call([
+      'lipo', arm64_dylib, simulator_x64_dylib, '-create', '-output', framework_binary
+  ])
+
+  process_framework(args, dst, framework_binary, framework_dsym)
+  return 0
+
+
+def embed_codesign_configuration(config_path, contents):
+  with open(config_path, 'w') as file:
+    file.write('\n'.join(contents) + '\n')
+
+
+def zip_archive(dst):
+  ios_file_with_entitlements = ['gen_snapshot_arm64']
+  ios_file_without_entitlements = [
+      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',  # pylint: disable=line-too-long
+      'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',  # pylint: disable=line-too-long
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter'  # pylint: disable=line-too-long
+  ]
+  embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), ios_file_with_entitlements)
+
+  embed_codesign_configuration(
+      os.path.join(dst, 'without_entitlements.txt'), ios_file_without_entitlements
+  )
+
+  subprocess.check_call([
+      'zip',
+      '-r',
+      'artifacts.zip',
+      'analyze_snapshot_arm64',
+      'gen_snapshot_arm64',
+      'Flutter.xcframework',
+      'entitlements.txt',
+      'without_entitlements.txt',
+      'extension_safe/Flutter.xcframework',
+  ],
+                        cwd=dst)
+
+  # Generate Flutter.dSYM.zip for manual symbolification.
+  #
+  # Historically, the framework dSYM was named Flutter.dSYM, so in order to
+  # remain backward-compatible with existing instructions in docs/Crashes.md
+  # and existing tooling such as dart-lang/dart_ci, we rename back to that name
+  #
+  # TODO(cbracken): remove these archives and the upload steps once we bundle
+  # dSYMs in app archives. https://github.com/flutter/flutter/issues/116493
+  framework_dsym = os.path.join(dst, 'Flutter.framework.dSYM')
+  if os.path.exists(framework_dsym):
+    renamed_dsym = framework_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(framework_dsym, renamed_dsym)
+    subprocess.check_call(['zip', '-r', 'Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
+
+  extension_safe_dsym = os.path.join(dst, 'extension_safe', 'Flutter.framework.dSYM')
+  if os.path.exists(extension_safe_dsym):
+    renamed_dsym = extension_safe_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(extension_safe_dsym, renamed_dsym)
+    subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
+
+
+def process_framework(args, dst, framework_binary, dsym):
+  if dsym:
+    subprocess.check_call([DSYMUTIL, '-o', dsym, framework_binary])
+
+  if args.strip:
+    # copy unstripped
+    unstripped_out = os.path.join(dst, 'Flutter.unstripped')
+    shutil.copyfile(framework_binary, unstripped_out)
+    subprocess.check_call(['strip', '-x', '-S', framework_binary])
+
+
+def generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir):
+  if x64_out_dir:
+    _generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
+
+  if arm64_out_dir:
+    _generate_gen_snapshot(
+        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_arm64')
+    )
+
+
+def _generate_gen_snapshot(directory, destination):
+  gen_snapshot_dir = os.path.join(directory, 'gen_snapshot')
+  if not os.path.isfile(gen_snapshot_dir):
+    print('Cannot find gen_snapshot at %s' % gen_snapshot_dir)
+    sys.exit(1)
+
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination])
+
+
+def generate_analyze_snapshot(args, dst, x64_out_dir, arm64_out_dir):
+  if x64_out_dir:
+    _generate_analyze_snapshot(x64_out_dir, os.path.join(dst, 'analyze_snapshot_x64'))
+
+  if arm64_out_dir:
+    _generate_analyze_snapshot(
+        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'analyze_snapshot_arm64')
+    )
+
+
+def _generate_analyze_snapshot(directory, destination):
+  analyze_snapshot_dir = os.path.join(directory, 'analyze_snapshot')
+  if not os.path.isfile(analyze_snapshot_dir):
+    print('Cannot find analyze_snapshot at %s' % analyze_snapshot_dir)
+    sys.exit(1)
+
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', analyze_snapshot_dir, '-o', destination])
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -444,6 +444,7 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
         make_test('platform_view_android_delegate_unittests'),
         # https://github.com/flutter/flutter/issues/36295
         make_test('shell_unittests'),
+        make_test('shorebird_unittests'),
     ]
 
   if is_windows():


### PR DESCRIPTION
## Rust Setup

In `engine/src/third_party/updater`, run:

```
rustup target add x86_64-pc-windows-msvc
cargo build --release --target x86_64-pc-windows-msvc
```

## Flutter Build

```
./flutter/tools/gn --runtime-mode release --no-rbe --no-lto
ninja -C .\out\host_release flutter/build/archives:windows_flutter
```

These commands were adapted from `ci\builders\windows_host_engine.json`

## Status

Currently failing for me during linking with:

```
PS C:\Users\bryan\shorebirdtech\engine\src> ninja -C .\out\host_release flutter/build/archives:windows_flutter
ninja: Entering directory `.\out\host_release'
[0/1] Regenerating ninja files//out/host_release/environment.x64
HOMEDRIVE=C:
[1/3] LINK(DLL) flutter_windows.dll flutter_windows.dll.exp flutter_windows.dll.lib flutter_windows.dll.pdb
FAILED: flutter_windows.dll flutter_windows.dll.exp flutter_windows.dll.lib flutter_windows.dll.pdb
"C:/Users/bryan/AppData/Local/.vpython-root/store/python_venv-kjq5i6tsfeg6rooeenghn4b26k/contents/Scripts/python3.exe" ../../build/toolchain/win/tool_wrapper.py link-wrapper environment.x64 False link.exe /nologo /IMPLIB:./flutter_windows.dll.lib /DLL /OUT:./flutter_windows.dll /PDB:./flutter_windows.dll.pdb @./flutter_windows.dll.rsp
b"LINK : warning LNK4098: defaultlib 'MSVCRT' conflicts with use of other libs; use /NODEFAULTLIB:library\r\n"
b"LINK : warning LNK4217: symbol 'calloc' defined in 'libucrt.lib(calloc.obj)' is imported by 'updater.lib(zstd_common.o)' in function 'ZSTD_customCalloc'\r\n"
b"LINK : warning LNK4286: symbol 'calloc' defined in 'libucrt.lib(calloc.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(fse_decompress.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(cover.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v06.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v07.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(divsufsort.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v02.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v03.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v04.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v05.o)'\r\n"
b"LINK : warning LNK4217: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_common.o)' in function 'ZSTD_customFree'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zdict.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(fse_compress.o)'\r\n"
b"LINK : warning LNK4286: symbol 'free' defined in 'libucrt.lib(free.obj)' is imported by 'updater.lib(zstd_v01.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(fse_decompress.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(cover.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v06.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v07.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(divsufsort.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v02.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v03.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v04.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v05.o)'\r\n"
b"LINK : warning LNK4217: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_common.o)' in function 'ZSTD_customMalloc'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zdict.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(fse_compress.o)'\r\n"
b"LINK : warning LNK4286: symbol 'malloc' defined in 'libucrt.lib(malloc.obj)' is imported by 'updater.lib(zstd_v01.o)'\r\n"
b"LINK : warning LNK4217: symbol '__acrt_iob_func' defined in 'libucrt.lib(_file.obj)' is imported by 'updater.lib(zdict.o)' in function 'ZDICT_addEntropyTablesFromBuffer_advanced'\r\n"
b"LINK : warning LNK4286: symbol '__acrt_iob_func' defined in 'libucrt.lib(_file.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4217: symbol '__acrt_iob_func' defined in 'libucrt.lib(_file.obj)' is imported by 'updater.lib(cover.o)' in function 'COVER_selectDict'\r\n"
b"LINK : warning LNK4217: symbol 'fflush' defined in 'libucrt.lib(fflush.obj)' is imported by 'updater.lib(zdict.o)' in function 'ZDICT_addEntropyTablesFromBuffer_advanced'\r\n"
b"LINK : warning LNK4286: symbol 'fflush' defined in 'libucrt.lib(fflush.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4217: symbol 'fflush' defined in 'libucrt.lib(fflush.obj)' is imported by 'updater.lib(cover.o)' in function 'COVER_ctx_init'\r\n"
b"LINK : warning LNK4217: symbol '__stdio_common_vfprintf' defined in 'libucrt.lib(output.obj)' is imported by 'updater.lib(zdict.o)' in function '_vfprintf_l'\r\n"
b"LINK : warning LNK4286: symbol '__stdio_common_vfprintf' defined in 'libucrt.lib(output.obj)' is imported by 'updater.lib(fastcover.o)'\r\n"
b"LINK : warning LNK4286: symbol '__stdio_common_vfprintf' defined in 'libucrt.lib(output.obj)' is imported by 'updater.lib(cover.o)'\r\n"
b"LINK : warning LNK4217: symbol 'qsort' defined in 'libucrt.lib(qsort.obj)' is imported by 'updater.lib(cover.o)' in function 'COVER_ctx_init'\r\n"
b'updater.lib(std-b84ff5acd6bc244a.std.bacbcc9a321ad2c6-cgu.0.rcgu.o) : error LNK2019: unresolved external symbol __imp_GetUserProfileDirectoryW referenced in function _ZN3std3env8home_dir17h0161835f45803d72E\r\n'
b'updater.lib(zdict.o) : error LNK2019: unresolved external symbol __imp_clock referenced in function ZDICT_clockSpan\r\n'
b'updater.lib(fastcover.o) : error LNK2001: unresolved external symbol __imp_clock\r\n'
b'updater.lib(cover.o) : error LNK2001: unresolved external symbol __imp_clock\r\n'
b'updater.lib(divsufsort.o) : error LNK2019: unresolved external symbol __imp__wassert referenced in function construct_BWT\r\n'
b'.\\flutter_windows.dll : fatal error LNK1120: 3 unresolved externals\r\n'
ninja: build stopped: subcommand failed.
```

## Other notes

The ninja build sometimes gets stuck in the following loop and I don't know why:

```
PS C:\Users\bryan\shorebirdtech\engine\src> ninja -C .\out\host_release flutter/build/archives:windows_flutter
ninja: Entering directory `.\out\host_release'
[0/1] Regenerating ninja files//out/host_release/environment.x64
HOMEDRIVE=C:
[0/1] Regenerating ninja files//out/host_release/environment.x64
HOMEDRIVE=C:
[0/1] Regenerating ninja files//out/host_release/environment.x64
HOMEDRIVE=C:
[0/1] Regenerating ninja files
```