### PR TITLE
Move configure shorebird call to platform embedder

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -112,14 +112,10 @@ group("flutter") {
 
         # path_ops
         "//flutter/tools/path_ops",
-      ]
 
-      if (host_os == "linux") {
-        public_deps += [
-          # Built alongside gen_snapshot for 64 bit targets
-          "$dart_src/runtime/bin:analyze_snapshot",
-        ]
-      }
+        # Built alongside gen_snapshot arm64 targets.
+        "$dart_src/runtime/bin:analyze_snapshot",
+      ]
 
       if (full_dart_sdk) {
         public_deps += [ "//flutter/web_sdk" ]
@@ -193,6 +189,7 @@ group("unittests") {
       "//flutter/runtime:no_dart_plugin_registrant_unittests",
       "//flutter/runtime:runtime_unittests",
       "//flutter/shell/common:shell_unittests",
+      "//flutter/shell/common/shorebird:shorebird_unittests",
       "//flutter/shell/platform/embedder:embedder_a11y_unittests",
       "//flutter/shell/platform/embedder:embedder_proctable_unittests",
       "//flutter/shell/platform/embedder:embedder_unittests",
@@ -317,5 +314,21 @@ if (host_os == "win") {
     gen_snapshot_out_dir = get_label_info(_gen_snapshot_target, "root_out_dir")
     sources = [ "$gen_snapshot_out_dir/gen_snapshot.exe" ]
     outputs = [ "$root_build_dir/gen_snapshot/gen_snapshot.exe" ]
+  }
+}
+
+# A top-level target for analyze_snapshot, modeled after the gen_snapshot
+# target above.
+if (host_os == "win") {
+  _analyze_snapshot_target =
+      "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)"
+
+  copy("analyze_snapshot") {
+    deps = [ _analyze_snapshot_target ]
+
+    analyze_snapshot_out_dir =
+        get_label_info(_analyze_snapshot_target, "root_out_dir")
+    sources = [ "$analyze_snapshot_out_dir/analyze_snapshot.exe" ]
+    outputs = [ "$root_build_dir/analyze_snapshot/analyze_snapshot.exe" ]
   }
 }

--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   "dart_sdk_revision": "4f9b5084a041a0e7cc26295da1da9109df43ac4c",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "1e4efce65f28d54c7a806ea05defd2ca3eb94595",
+  "updater_rev": "38aadee1c5e0a072dd40ee8778bea2f67dd8ec46",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   "dart_sdk_revision": "4f9b5084a041a0e7cc26295da1da9109df43ac4c",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "38aadee1c5e0a072dd40ee8778bea2f67dd8ec46",
+  "updater_rev": "54e1e2ce2f82e5fe004bd0730c00d4310ab637dc",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/DEPS
+++ b/DEPS
@@ -279,7 +279,7 @@ allowed_hosts = [
 ]
 
 deps = {
-  'src': 'https://github.com/flutter/buildroot.git' + '@' + 'f85c3be4bf808add6ba867b8ff7943fd235b7b5e',
+  'src': 'https://github.com/shorebirdtech/buildroot.git' + '@' + '4c5c8abd2ab1ac7c2c029503c71450a87bf94307',
 
   'src/flutter/third_party/depot_tools':
   Var('chromium_git') + '/chromium/tools/depot_tools.git' + '@' + '580b4ff3f5cd0dcaa2eacda28cefe0f45320e8f7',

--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   "dart_sdk_revision": "4f9b5084a041a0e7cc26295da1da9109df43ac4c",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "54e1e2ce2f82e5fe004bd0730c00d4310ab637dc",
+  "updater_rev": "71b5ed65fab03fcf241edf0c74d027de9998da51",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/DEPS
+++ b/DEPS
@@ -15,6 +15,10 @@ vars = {
   'skia_git': 'https://skia.googlesource.com',
   'llvm_git': 'https://llvm.googlesource.com',
   'skia_revision': '6062afaa505bf7e6c727a20cafe4c7bee0f02df8',
+  "dart_sdk_revision": "4f9b5084a041a0e7cc26295da1da9109df43ac4c",
+  "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
+  "updater_git": "https://github.com/shorebirdtech/updater.git",
+  "updater_rev": "1e4efce65f28d54c7a806ea05defd2ca3eb94595",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.
@@ -258,22 +262,20 @@ vars = {
   'fuchsia_gn_sdk_version': 'tHRCseOuPnZ5H4a7kb4Zl6YQ2rhEDWIzcEX3G9NPFhkC',
 }
 
-gclient_gn_args_file = 'src/flutter/third_party/dart/build/config/gclient_args.gni'
-gclient_gn_args = [
-  'checkout_llvm'
-]
+gclient_gn_args_file = "src/flutter/third_party/dart/build/config/gclient_args.gni"
+gclient_gn_args = ["checkout_llvm"]
 
 # Only these hosts are allowed for dependencies in this DEPS file.
 # If you need to add a new host, contact chrome infrastructure team.
 allowed_hosts = [
-  'boringssl.googlesource.com',
-  'chrome-infra-packages.appspot.com',
-  'chromium.googlesource.com',
-  'dart.googlesource.com',
-  'flutter.googlesource.com',
-  'llvm.googlesource.com',
-  'skia.googlesource.com',
-  'swiftshader.googlesource.com',
+    "boringssl.googlesource.com",
+    "chrome-infra-packages.appspot.com",
+    "chromium.googlesource.com",
+    "dart.googlesource.com",
+    "flutter.googlesource.com",
+    "llvm.googlesource.com",
+    "skia.googlesource.com",
+    "swiftshader.googlesource.com",
 ]
 
 deps = {
@@ -339,7 +341,7 @@ deps = {
   #  Var('flutter_git') + '/third_party/protobuf-gn' + '@' + Var('dart_protobuf_gn_rev'),
 
   'src/flutter/third_party/dart':
-   Var('dart_git') + '/sdk.git' + '@' + Var('dart_revision'),
+   Var('dart_sdk_git') + '@' + Var('dart_sdk_revision'),
 
   # WARNING: Unused Dart dependencies in the list below till "WARNING:" marker are removed automatically - see create_updated_flutter_deps.py.
 
@@ -631,6 +633,9 @@ deps = {
 
   'src/flutter/third_party/ocmock':
    Var('flutter_git') + '/third_party/ocmock' + '@' +  Var('ocmock_rev'),
+
+   'src/third_party/updater':
+   Var('updater_git') + '@' + Var('updater_rev'),
 
   'src/flutter/third_party/libjpeg-turbo/src':
    Var('flutter_git') + '/third_party/libjpeg-turbo' + '@' + '0fb821f3b2e570b2783a94ccd9a2fb1f4916ae9f',
@@ -1018,157 +1023,165 @@ deps = {
 }
 
 recursedeps = [
-  'src/flutter/third_party/vulkan-deps',
+    "src/flutter/third_party/vulkan-deps",
 ]
 
 hooks = [
-  {
-    # Generate the Dart SDK's .dart_tool/package_confg.json file.
-    'name': 'Generate .dart_tool/package_confg.json',
-    'pattern': '.',
-    'action': ['python3', 'src/flutter/third_party/dart/tools/generate_package_config.py'],
-  },
-  {
-    # Generate the sdk/version file.
-    'name': 'Generate sdk/version',
-    'pattern': '.',
-    'action': ['python3', 'src/flutter/third_party/dart/tools/generate_sdk_version_file.py'],
-  },
-  {
-    # Update the Windows toolchain if necessary.
-    'name': 'win_toolchain',
-    'condition': 'download_windows_deps',
-    'pattern': '.',
-    'action': ['python3', 'src/build/vs_toolchain.py', 'update'],
-  },
-  {
-    'name': 'dia_dll',
-    'pattern': '.',
-    'condition': 'download_windows_deps',
-    'action': [
-      'python3',
-      'src/flutter/tools/dia_dll.py',
-    ],
-  },
-  {
-    'name': 'linux_sysroot_x64',
-    'pattern': '.',
-    'condition': 'download_linux_deps',
-    'action': [
-      'python3',
-      'src/build/linux/sysroot_scripts/install-sysroot.py',
-      '--arch=x64'],
-  },
-  {
-    'name': 'linux_sysroot_arm64',
-    'pattern': '.',
-    'condition': 'download_linux_deps',
-    'action': [
-      'python3',
-      'src/build/linux/sysroot_scripts/install-sysroot.py',
-      '--arch=arm64'],
-  },
-  {
-    'name': 'pub get --offline',
-    'pattern': '.',
-    'action': [
-      'python3',
-      'src/flutter/tools/pub_get_offline.py',
-    ]
-  },
-  {
-    'name': 'Download Fuchsia SDK',
-    'pattern': '.',
-    'condition': 'download_fuchsia_deps and download_fuchsia_sdk',
-    'action': [
-      'python3',
-      'src/flutter/tools/download_fuchsia_sdk.py',
-      '--fail-loudly',
-      '--verbose',
-      '--host-os',
-      Var('host_os'),
-      '--fuchsia-sdk-path',
-      Var('fuchsia_sdk_path'),
-    ]
-  },
-  {
-    'name': 'Activate Emscripten SDK',
-    'pattern': '.',
-    'condition': 'download_emsdk',
-    'action': [
-      'python3',
-      'src/flutter/tools/activate_emsdk.py',
-    ]
-  },
-  {
-    'name': 'Setup githooks',
-    'pattern': '.',
-    'condition': 'setup_githooks',
-    'action': [
-      'python3',
-      'src/flutter/tools/githooks/setup.py',
-    ]
-  },
-  {
-    'name': 'impeller-cmake-example submodules',
-    'pattern': '.',
-    'condition': 'download_impeller_cmake_example',
-    'action': [
-      'python3',
-      'src/flutter/ci/impeller_cmake_build_test.py',
-      '--path',
-      'flutter/third_party/impeller-cmake-example',
-      '--setup',
-    ]
-  },
-  {
-    'name': 'Download Fuchsia system images',
-    'pattern': '.',
-    'condition': 'run_fuchsia_emu',
-    'action': [
-      'env',
-      'DOWNLOAD_FUCHSIA_SDK={download_fuchsia_sdk}',
-      'FUCHSIA_SDK_PATH={fuchsia_sdk_path}',
-      'python3',
-      'src/flutter/tools/fuchsia/with_envs.py',
-      'src/flutter/tools/fuchsia/test_scripts/update_product_bundles.py',
-      'terminal.x64,terminal.qemu-arm64',
-    ]
-  },
-  # The following two scripts check if they are running in the LUCI
-  # environment, and do nothing if so. This is because Xcode is not yet
-  # installed in CI when these hooks are run.
-  {
-    'name': 'Find the iOS device SDKs',
-    'pattern': '.',
-    'condition': 'host_os == "mac"',
-    'action': [
-      'python3',
-      'src/build/config/ios/ios_sdk.py',
-      # This cleans up entries under flutter/prebuilts for this script and the
-      # following script.
-      '--as-gclient-hook'
-    ]
-  },
-  {
-    'name': 'Find the macOS SDK',
-    'pattern': '.',
-    'condition': 'host_os == "mac"',
-    'action': [
-      'python3',
-      'src/build/mac/find_sdk.py',
-      '--as-gclient-hook',
-      Var('mac_sdk_min')
-    ]
-  },
-  {
-    'name': 'Generate Fuchsia GN build rules',
-    'pattern': '.',
-    'condition': 'download_fuchsia_deps',
-    'action': [
-      'python3',
-      'src/flutter/tools/fuchsia/with_envs.py',
-      'src/flutter/tools/fuchsia/test_scripts/gen_build_defs.py',
-    ],
-  },
+    {
+        # Generate the Dart SDK's .dart_tool/package_confg.json file.
+        "name": "Generate .dart_tool/package_confg.json",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/third_party/dart/tools/generate_package_config.py",
+        ],
+    },
+    {
+        # Generate the sdk/version file.
+        "name": "Generate sdk/version",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/third_party/dart/tools/generate_sdk_version_file.py",
+        ],
+    },
+    {
+        # Update the Windows toolchain if necessary.
+        "name": "win_toolchain",
+        "condition": "download_windows_deps",
+        "pattern": ".",
+        "action": ["python3", "src/build/vs_toolchain.py", "update"],
+    },
+    {
+        "name": "dia_dll",
+        "pattern": ".",
+        "condition": "download_windows_deps",
+        "action": [
+            "python3",
+            "src/flutter/tools/dia_dll.py",
+        ],
+    },
+    {
+        "name": "linux_sysroot_x64",
+        "pattern": ".",
+        "condition": "download_linux_deps",
+        "action": [
+            "python3",
+            "src/build/linux/sysroot_scripts/install-sysroot.py",
+            "--arch=x64",
+        ],
+    },
+    {
+        "name": "linux_sysroot_arm64",
+        "pattern": ".",
+        "condition": "download_linux_deps",
+        "action": [
+            "python3",
+            "src/build/linux/sysroot_scripts/install-sysroot.py",
+            "--arch=arm64",
+        ],
+    },
+    {
+        "name": "pub get --offline",
+        "pattern": ".",
+        "action": [
+            "python3",
+            "src/flutter/tools/pub_get_offline.py",
+        ],
+    },
+    {
+        "name": "Download Fuchsia SDK",
+        "pattern": ".",
+        "condition": "download_fuchsia_deps and download_fuchsia_sdk",
+        "action": [
+            "python3",
+            "src/flutter/tools/download_fuchsia_sdk.py",
+            "--fail-loudly",
+            "--verbose",
+            "--host-os",
+            Var("host_os"),
+            "--fuchsia-sdk-path",
+            Var("fuchsia_sdk_path"),
+        ],
+    },
+    {
+        "name": "Activate Emscripten SDK",
+        "pattern": ".",
+        "condition": "download_emsdk",
+        "action": [
+            "python3",
+            "src/flutter/tools/activate_emsdk.py",
+        ],
+    },
+    {
+        "name": "Setup githooks",
+        "pattern": ".",
+        "condition": "setup_githooks",
+        "action": [
+            "python3",
+            "src/flutter/tools/githooks/setup.py",
+        ],
+    },
+    {
+        "name": "impeller-cmake-example submodules",
+        "pattern": ".",
+        "condition": "download_impeller_cmake_example",
+        "action": [
+            "python3",
+            "src/flutter/ci/impeller_cmake_build_test.py",
+            "--path",
+            "flutter/third_party/impeller-cmake-example",
+            "--setup",
+        ],
+    },
+    {
+        "name": "Download Fuchsia system images",
+        "pattern": ".",
+        "condition": "run_fuchsia_emu",
+        "action": [
+            "env",
+            "DOWNLOAD_FUCHSIA_SDK={download_fuchsia_sdk}",
+            "FUCHSIA_SDK_PATH={fuchsia_sdk_path}",
+            "python3",
+            "src/flutter/tools/fuchsia/with_envs.py",
+            "src/flutter/tools/fuchsia/test_scripts/update_product_bundles.py",
+            "terminal.x64,terminal.qemu-arm64",
+        ],
+    },
+    # The following two scripts check if they are running in the LUCI
+    # environment, and do nothing if so. This is because Xcode is not yet
+    # installed in CI when these hooks are run.
+    {
+        "name": "Find the iOS device SDKs",
+        "pattern": ".",
+        "condition": 'host_os == "mac"',
+        "action": [
+            "python3",
+            "src/build/config/ios/ios_sdk.py",
+            # This cleans up entries under flutter/prebuilts for this script and the
+            # following script.
+            "--as-gclient-hook",
+        ],
+    },
+    {
+        "name": "Find the macOS SDK",
+        "pattern": ".",
+        "condition": 'host_os == "mac"',
+        "action": [
+            "python3",
+            "src/build/mac/find_sdk.py",
+            "--as-gclient-hook",
+            Var("mac_sdk_min"),
+        ],
+    },
+    {
+        "name": "Generate Fuchsia GN build rules",
+        "pattern": ".",
+        "condition": "download_fuchsia_deps",
+        "action": [
+            "python3",
+            "src/flutter/tools/fuchsia/with_envs.py",
+            "src/flutter/tools/fuchsia/test_scripts/gen_build_defs.py",
+        ],
+    },
 ]

--- a/build/archives/BUILD.gn
+++ b/build/archives/BUILD.gn
@@ -45,6 +45,7 @@ generated_file("artifacts_entitlement_config") {
 if (build_engine_artifacts) {
   zip_bundle("artifacts") {
     deps = [
+      "$dart_src/runtime/bin:analyze_snapshot",
       "$dart_src/runtime/bin:gen_snapshot",
       "//flutter/flutter_frontend_server:frontend_server",
       "//flutter/impeller/compiler:impellerc",
@@ -139,6 +140,10 @@ if (build_engine_artifacts) {
     if (host_os == "mac") {
       deps += [ ":artifacts_entitlement_config" ]
       files += [
+        {
+          source = "$root_out_dir/analyze_snapshot$exe"
+          destination = "analyze_snapshot$exe"
+        },
         {
           source = "$target_gen_dir/entitlements.txt"
           destination = "entitlements.txt"
@@ -308,13 +313,24 @@ if (is_mac) {
 }
 
 if (host_os == "win") {
+  # This rule archives both gen_snapshot *and* analyze_snapshot. The name is
+  # misleading. We (shorebird) have updated this rule to include
+  # analyze_snapshot but did not update the name because it is referenced
+  # elsewhere in the tooling.
   zip_bundle("archive_win_gen_snapshot") {
-    deps = [ "//flutter:gen_snapshot" ]
+    deps = [
+      "//flutter:analyze_snapshot",
+      "//flutter:gen_snapshot",
+    ]
     output = "$full_target_platform_name-$flutter_runtime_mode/windows-x64.zip"
     files = [
       {
         source = "$root_out_dir/gen_snapshot/gen_snapshot.exe"
         destination = "gen_snapshot.exe"
+      },
+      {
+        source = "$root_out_dir/analyze_snapshot/analyze_snapshot.exe"
+        destination = "analyze_snapshot.exe"
       },
     ]
   }

--- a/common/config.gni
+++ b/common/config.gni
@@ -78,6 +78,10 @@ if (is_ios || is_mac || is_android || is_win) {
 }
 
 if (is_ios || is_mac) {
+  feature_defines_list += [ "SHOREBIRD_USES_MIXED_MODE=1" ]
+}
+
+if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",
     "-Werror=undeclared-selector",

--- a/common/config.gni
+++ b/common/config.gni
@@ -73,6 +73,10 @@ if (slimpeller) {
   feature_defines_list += [ "SLIMPELLER=1" ]
 }
 
+if (is_ios || is_mac || is_android || is_win) {
+  feature_defines_list += [ "SHOREBIRD_PLATFORM_SUPPORTED=1" ]
+}
+
 if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,10 +37,11 @@ group("generate_snapshot_bins") {
     deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [
-      ":create_arm_analyze_snapshot",
-      ":create_arm_gen_snapshot",
-    ]
+    deps += [ ":create_arm_gen_snapshot" ]
+  }
+
+  if (host_os == "mac" && target_os != "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+    deps += [ ":create_arm_analyze_snapshot" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -34,15 +34,13 @@ group("generate_snapshot_bins") {
   # For macOS target builds: needed for both target CPUs (arm64, x64).
   # For iOS, Android target builds: all AOT target CPUs are arm/arm64.
   if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
-    deps += [ ":create_macos_gen_snapshots" ]
+    deps += [
+      ":create_macos_analyze_snapshots",
+      ":create_macos_gen_snapshots",
+    ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_gen_snapshot" ]
-  }
-
-  if (host_os == "mac" && target_os != "mac" &&
-      (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_analyze_snapshot" ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
@@ -181,25 +179,6 @@ if (host_os == "mac" && target_os != "mac" &&
     deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
-
-  copy("create_arm_analyze_snapshot") {
-    # The toolchain-specific output directory. For cross-compiles, this is a
-    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
-    host_output_dir = get_label_info(
-            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
-            "root_out_dir")
-
-    # Determine suffixed output gen_snapshot name.
-    target_cpu_suffix = target_cpu
-    if (target_cpu == "arm") {
-      target_cpu_suffix = "armv7"
-    }
-
-    sources = [ "${host_output_dir}/analyze_snapshot" ]
-    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
-    deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
-    visibility = [ ":*" ]
-  }
 }
 
 # Creates a `gen_snapshot` binary suffixed with the target CPU architecture.
@@ -256,6 +235,69 @@ if (host_os == "mac" && (target_os == "mac" || target_os == "ios")) {
     deps = [
       ":create_macos_gen_snapshot_arm64_${target_cpu}",
       ":create_macos_gen_snapshot_x64_${target_cpu}",
+    ]
+  }
+
+  # Added by shorebird.
+  # analyze_snapshot targets below were copied from the gen_snapshot targets
+  # above to allow us to include analyze_snapshot in the artifacts generated
+  # for create_ios_framework.py.
+  template("build_mac_analyze_snapshot") {
+    assert(defined(invoker.host_arch))
+    host_cpu = invoker.host_arch
+
+    build_toolchain = "//build/toolchain/mac:clang_$host_cpu"
+    analyze_snapshot_target_name = "analyze_snapshot"
+
+    # At this point, the gen_snapshot equivalent changes
+    # gen_ snapshot_target_name to "gen_snapshot_host_targeting_host". There is
+    # no equivalent for analyze_snapshot, so we don't do that here.
+    #
+    # It's unclear whether we need to do so now, but we didn't previously, so
+    # we're not doing it now until we have a reason to.
+
+    analyze_snapshot_target =
+        "$dart_src/runtime/bin:$analyze_snapshot_target_name($build_toolchain)"
+
+    copy(target_name) {
+      # The toolchain-specific output directory. For cross-compiles, this is a
+      # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+      output_dir = get_label_info(analyze_snapshot_target, "root_out_dir")
+
+      sources = [ "${output_dir}/${analyze_snapshot_target_name}" ]
+      outputs = [
+        "${root_out_dir}/artifacts_$host_cpu/analyze_snapshot_${target_cpu}",
+      ]
+      deps = [ analyze_snapshot_target ]
+    }
+  }
+
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_arm64_${target_cpu}") {
+    host_arch = "arm64"
+  }
+
+  build_mac_analyze_snapshot(
+      "create_macos_analyze_snapshot_x64_${target_cpu}") {
+    host_arch = "x64"
+  }
+
+  action("create_macos_analyze_snapshots") {
+    script = "//flutter/sky/tools/create_macos_binary.py"
+    outputs = [ "${root_out_dir}/analyze_snapshot_${target_cpu}" ]
+    args = [
+      "--in-arm64",
+      rebase_path(
+          "${root_out_dir}/artifacts_arm64/analyze_snapshot_${target_cpu}"),
+      "--in-x64",
+      rebase_path(
+          "${root_out_dir}/artifacts_x64/analyze_snapshot_${target_cpu}"),
+      "--out",
+      rebase_path("${root_out_dir}/analyze_snapshot_${target_cpu}"),
+    ]
+    deps = [
+      ":create_macos_analyze_snapshot_arm64_${target_cpu}",
+      ":create_macos_analyze_snapshot_x64_${target_cpu}",
     ]
   }
 }

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -40,7 +40,8 @@ group("generate_snapshot_bins") {
     deps += [ ":create_arm_gen_snapshot" ]
   }
 
-  if (host_os == "mac" && target_os != "mac" && (target_cpu == "arm" || target_cpu == "arm64")) {
+  if (host_os == "mac" && target_os != "mac" &&
+      (target_cpu == "arm" || target_cpu == "arm64")) {
     deps += [ ":create_arm_analyze_snapshot" ]
   }
 

--- a/lib/snapshot/BUILD.gn
+++ b/lib/snapshot/BUILD.gn
@@ -37,11 +37,14 @@ group("generate_snapshot_bins") {
     deps += [ ":create_macos_gen_snapshots" ]
   } else if (host_os == "mac" &&
              (target_cpu == "arm" || target_cpu == "arm64")) {
-    deps += [ ":create_arm_gen_snapshot" ]
+    deps += [
+      ":create_arm_analyze_snapshot",
+      ":create_arm_gen_snapshot",
+    ]
   }
 
   # Build analyze_snapshot for 64-bit target CPUs.
-  if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+  if (target_cpu == "arm64") {
     deps += [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
   }
 }
@@ -174,6 +177,25 @@ if (host_os == "mac" && target_os != "mac" &&
     sources = [ "${host_output_dir}/gen_snapshot" ]
     outputs = [ "${host_output_dir}/gen_snapshot_${target_cpu_suffix}" ]
     deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    visibility = [ ":*" ]
+  }
+
+  copy("create_arm_analyze_snapshot") {
+    # The toolchain-specific output directory. For cross-compiles, this is a
+    # clang-x64 or clang-arm64 subdirectory of the top-level build directory.
+    host_output_dir = get_label_info(
+            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+
+    # Determine suffixed output gen_snapshot name.
+    target_cpu_suffix = target_cpu
+    if (target_cpu == "arm") {
+      target_cpu_suffix = "armv7"
+    }
+
+    sources = [ "${host_output_dir}/analyze_snapshot" ]
+    outputs = [ "${host_output_dir}/analyze_snapshot_${target_cpu_suffix}" ]
+    deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
     visibility = [ ":*" ]
   }
 }

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -6,6 +6,7 @@
 
 #include <sstream>
 
+#include <third_party/dart/runtime/bin/elf_loader.h>
 #include "flutter/fml/native_library.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
@@ -56,33 +57,93 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
-  // Ask the embedder. There is no fallback as we expect the embedders (via
-  // their embedding APIs) to just specify the mappings directly.
-  if (embedder_mapping_callback) {
-    // Note that mapping will be nullptr if the mapping callback returns an
-    // invalid mapping. If all the other methods for resolving the data also
-    // fail, the engine will stop with accompanying error logs.
-    if (auto mapping = embedder_mapping_callback()) {
-      return mapping;
-    }
-  }
+#if FML_OS_IOS || FML_OS_MACOSX
+  // Detect when we're trying to load a Shorebird patch.
+  auto patch_path = native_library_path.front();
+  bool is_patch = patch_path.find(".vmcode") != std::string::npos;
+  if (is_patch) {
+    // We use this terrible hack to load in the patch and then extract the
+    // symbols from it when the path is not App.framework/App but rather
+    // foo.vmcode, etc. We read the symbols into static variables, but then I
+    // believe we need to hold onto the ELF itself, otherwise the symbols
+    // become invalid.
+    // "leaked_elf" is meant to indicate that we're not freeing the ELF.
+    static Dart_LoadedElf* leaked_elf = nullptr;
+    // The VM Snapshot is identical for all binaries produced by a given version
+    // of Dart.  Our linker checks this and will fail to link if ever the VM
+    // snapshot changes.
+    const uint8_t* ignored_vm_data = nullptr;
+    const uint8_t* ignored_vm_instrs = nullptr;
+    static const uint8_t* isolate_data = nullptr;
+    static const uint8_t* isolate_instrs = nullptr;
+    if (leaked_elf == nullptr) {
+      const char* error = nullptr;
+      // vmcode files are elf files prefixed with a shorebird linker header.
+      auto elf_mapping = GetFileMapping(patch_path, false /* executable */);
+      int elf_file_offset = Shorebird_ReadLinkHeader(elf_mapping->GetMapping(),
+                                                     elf_mapping->GetSize());
 
-  // Attempt to open file at path specified.
-  if (!file_path.empty()) {
-    if (auto file_mapping = GetFileMapping(file_path, is_executable)) {
-      return file_mapping;
+      leaked_elf = Dart_LoadELF(patch_path.c_str(), elf_file_offset, &error,
+                                &ignored_vm_data, &ignored_vm_instrs,
+                                &isolate_data, &isolate_instrs,
+                                /* load as read-only, not rx */ false);
+      if (leaked_elf != nullptr) {
+        FML_LOG(INFO) << "Loaded ELF";
+      } else {
+        FML_LOG(FATAL) << "Failed to load ELF at " << patch_path
+                       << " error: " << error;
+        abort();
+      }
     }
-  }
 
-  // Look in application specified native library if specified.
-  for (const std::string& path : native_library_path) {
-    auto native_library = fml::NativeLibrary::Create(path.c_str());
-    auto symbol_mapping = std::make_unique<const fml::SymbolMapping>(
-        native_library, native_library_symbol_name);
-    if (symbol_mapping->GetMapping() != nullptr) {
-      return symbol_mapping;
+    FML_LOG(INFO) << "Loading symbol from ELF " << native_library_symbol_name;
+
+    if (native_library_symbol_name == DartSnapshot::kIsolateDataSymbol) {
+      return std::make_unique<const fml::NonOwnedMapping>(isolate_data, 0,
+                                                          nullptr, true);
+    } else if (native_library_symbol_name ==
+               DartSnapshot::kIsolateInstructionsSymbol) {
+      return std::make_unique<const fml::NonOwnedMapping>(isolate_instrs, 0,
+                                                          nullptr, true);
     }
-  }
+    // Fall through to normal lookups for VM data and instructions.
+    // This fallthrough depends on the fact that NativeLibrary below can't
+    // read the ELF out of our .vmcode files.
+  } else {
+    // Only try to open the file if we're not loading a patch.
+#endif
+
+    // Ask the embedder. There is no fallback as we expect the embedders (via
+    // their embedding APIs) to just specify the mappings directly.
+    if (embedder_mapping_callback) {
+      // Note that mapping will be nullptr if the mapping callback returns an
+      // invalid mapping. If all the other methods for resolving the data also
+      // fail, the engine will stop with accompanying error logs.
+      if (auto mapping = embedder_mapping_callback()) {
+        return mapping;
+      }
+    }
+
+    // Attempt to open file at path specified.
+    if (!file_path.empty()) {
+      if (auto file_mapping = GetFileMapping(file_path, is_executable)) {
+        return file_mapping;
+      }
+    }
+
+    // Look in application specified native library if specified.
+    for (const std::string& path : native_library_path) {
+      auto native_library = fml::NativeLibrary::Create(path.c_str());
+      auto symbol_mapping = std::make_unique<const fml::SymbolMapping>(
+          native_library, native_library_symbol_name);
+      if (symbol_mapping->GetMapping() != nullptr) {
+        return symbol_mapping;
+      }
+    }
+
+#if FML_OS_IOS || FML_OS_MACOSX
+  }  // !is_patch
+#endif
 
   // Look inside the currently loaded process.
   {

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -57,7 +57,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
-#if FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_USES_MIXED_MODE
   // Detect when we're trying to load a Shorebird patch.
   auto patch_path = native_library_path.front();
   bool is_patch = patch_path.find(".vmcode") != std::string::npos;

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -152,6 +152,8 @@ source_set("common") {
     "//flutter/skia",
   ]
 
+  include_dirs = [ "//flutter/updater" ]
+
   if (impeller_supports_rendering) {
     sources += [
       "snapshot_controller_impeller.cc",
@@ -159,6 +161,17 @@ source_set("common") {
     ]
 
     deps += [ "//flutter/impeller" ]
+  }
+
+  # Needed to compile flutter_tester for macOS.
+  if (host_os == "mac" && target_os == "mac") {
+    if (target_cpu == "arm64") {
+      libs = [ "//third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
+    } else if (target_cpu == "x64") {
+      libs = [
+        "//third_party/updater/target/x86_64-apple-darwin/release/libupdater.a",
+      ]
+    }
   }
 }
 

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -173,7 +173,7 @@ source_set("common") {
       ]
     }
   }
-  
+
   # Needed to compile flutter_tester for Windows.
   if (host_os == "win" && target_os == "win") {
     if (target_cpu == "x64") {

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -173,6 +173,16 @@ source_set("common") {
       ]
     }
   }
+  
+  # Needed to compile flutter_tester for Windows.
+  if (host_os == "win" && target_os == "win") {
+    if (target_cpu == "x64") {
+      libs = [
+        "userenv.lib",
+        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
+      ]
+    }
+  }
 }
 
 # These are in their own source_set to avoid a dependency cycle with //common/graphics

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -444,7 +444,7 @@ Shell::Shell(DartVMRef vm,
       weak_factory_gpu_(nullptr),
       weak_factory_(this) {
   // FIXME: This is probably the wrong place to hook into.
-#if FML_OS_ANDROID || FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_PLATFORM_SUPPORTED
   if (!vm_) {
     shorebird_report_launch_failure();
   } else {

--- a/shell/common/shell.cc
+++ b/shell/common/shell.cc
@@ -43,6 +43,8 @@
 #include "third_party/skia/include/core/SkGraphics.h"
 #include "third_party/tonic/common/log.h"
 
+#include "third_party/updater/library/include/updater.h"
+
 namespace flutter {
 
 constexpr char kSkiaChannel[] = "flutter/skia";
@@ -441,6 +443,14 @@ Shell::Shell(DartVMRef vm,
       is_gpu_disabled_sync_switch_(new fml::SyncSwitch(is_gpu_disabled)),
       weak_factory_gpu_(nullptr),
       weak_factory_(this) {
+  // FIXME: This is probably the wrong place to hook into.
+#if FML_OS_ANDROID || FML_OS_IOS || FML_OS_MACOSX
+  if (!vm_) {
+    shorebird_report_launch_failure();
+  } else {
+    shorebird_report_launch_success();
+  }
+#endif
   FML_CHECK(!settings.enable_software_rendering || !settings.enable_impeller)
       << "Software rendering is incompatible with Impeller.";
   if (!settings.enable_impeller && settings.warn_on_impeller_opt_out) {

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -1,0 +1,56 @@
+import("//flutter/common/config.gni")
+import("//flutter/testing/testing.gni")
+
+source_set("snapshots_data_handle") {
+  sources = [
+    "snapshots_data_handle.cc",
+    "snapshots_data_handle.h",
+  ]
+
+  deps = [
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
+  ]
+}
+
+source_set("shorebird") {
+  sources = [
+    "shorebird.cc",
+    "shorebird.h",
+  ]
+
+  deps = [
+    ":snapshots_data_handle",
+    "//flutter/fml",
+    "//flutter/runtime",
+    "//flutter/runtime:libdart",
+    "//flutter/shell/common",
+    "//flutter/shell/platform/embedder:embedder_headers",
+  ]
+
+  include_dirs = [ "//flutter/updater" ]
+}
+
+if (enable_unittests) {
+  test_fixtures("shorebird_fixtures") {
+    fixtures = []
+  }
+
+  executable("shorebird_unittests") {
+    testonly = true
+
+    sources = [ "snapshots_data_handle_unittests.cc" ]
+
+    # This only includes snapshots_data_handle and not shorebird because
+    # shorebird fails to link due to a missing updater lib.
+    deps = [
+      ":shorebird_fixtures",
+      ":snapshots_data_handle",
+      "//flutter/runtime",
+      "//flutter/testing",
+      "//flutter/testing:fixture_test",
+    ]
+  }
+}

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -31,6 +31,15 @@ source_set("shorebird") {
   ]
 
   include_dirs = [ "//flutter/updater" ]
+
+  if (host_os == "win" && target_os == "win") {
+    if (target_cpu == "x64") {
+      libs = [
+        "userenv.lib",
+        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
+      ]
+    }
+  }
 }
 
 if (enable_unittests) {

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -31,15 +31,6 @@ source_set("shorebird") {
   ]
 
   include_dirs = [ "//flutter/updater" ]
-
-  if (host_os == "win" && target_os == "win") {
-    if (target_cpu == "x64") {
-      libs = [
-        "userenv.lib",
-        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
-      ]
-    }
-  }
 }
 
 if (enable_unittests) {

--- a/shell/common/shorebird/BUILD.gn
+++ b/shell/common/shorebird/BUILD.gn
@@ -27,7 +27,6 @@ source_set("shorebird") {
     "//flutter/runtime",
     "//flutter/runtime:libdart",
     "//flutter/shell/common",
-    "//flutter/shell/platform/embedder:embedder_headers",
   ]
 
   include_dirs = [ "//flutter/updater" ]

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -21,6 +21,7 @@
 #include "flutter/shell/common/shorebird/snapshots_data_handle.h"
 #include "flutter/shell/common/switches.h"
 #include "fml/logging.h"
+#include "shell/platform/embedder/embedder.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 
 #include "third_party/updater/library/include/updater.h"
@@ -79,8 +80,100 @@ FileCallbacks ShorebirdFileCallbacks() {
   };
 }
 
+// FIXME: consolidate this with the other ConfigureShorebird
+bool ConfigureShorebird(const ShorebirdConfigArgs& args,
+                        std::string& patch_path) {
+  patch_path = args.release_app_library_path;
+  auto shorebird_updater_dir_name = "shorebird_updater";
+
+  auto code_cache_dir = fml::paths::JoinPaths(
+      {std::move(args.code_cache_path), shorebird_updater_dir_name});
+  auto app_storage_dir = fml::paths::JoinPaths(
+      {std::move(args.app_storage_path), shorebird_updater_dir_name});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(),
+                       {shorebird_updater_dir_name},
+                       fml::FilePermission::kReadWrite);
+
+  bool init_result;
+  // Using a block to make AppParameters lifetime explicit.
+  {
+    AppParameters app_parameters;
+    // Combine version and version_code into a single string.
+    // We could also pass these separately through to the updater if needed.
+    auto release_version =
+        args.release_version.version + "+" + args.release_version.build_number;
+    app_parameters.release_version = release_version.c_str();
+    app_parameters.code_cache_dir = code_cache_dir.c_str();
+    app_parameters.app_storage_dir = app_storage_dir.c_str();
+
+    // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
+    std::vector<const char*> c_paths{};
+    c_paths.push_back(args.release_app_library_path.c_str());
+    // Do not modify application_library_path or c_strings will invalidate.
+
+    app_parameters.original_libapp_paths = c_paths.data();
+    app_parameters.original_libapp_paths_size = c_paths.size();
+
+    // shorebird_init copies from app_parameters and shorebirdYaml.
+    init_result = shorebird_init(&app_parameters, ShorebirdFileCallbacks(),
+                                 args.shorebird_yaml.c_str());
+  }
+
+  // We've decided not to support synchronous updates on launch for now.
+  // It's a terrible user experience (having the app hang on launch) and
+  // instead we will provide examples of how to build a custom update UI
+  // within Dart, including updating as part of login, etc.
+  // https://github.com/shorebirdtech/shorebird/issues/950
+
+  // We only set the base snapshot on iOS for now.
+  // TODO: this won't compile as we don't have a settings object here.
+  // #if FML_OS_IOS || FML_OS_MACOSX
+  //   SetBaseSnapshot(settings);
+  // #endif
+
+  FML_LOG(INFO) << "Checking for active patch";
+  char* c_active_path = shorebird_next_boot_patch_path();
+  if (c_active_path != NULL) {
+    patch_path = c_active_path;
+    shorebird_free_string(c_active_path);
+    FML_LOG(INFO) << "Shorebird updater: patch path: " << patch_path;
+  } else {
+    FML_LOG(INFO) << "Shorebird updater: no active patch.";
+  }
+
+  // We are careful only to report a launch start in the case where it's the
+  // first time we've configured shorebird this process. Otherwise we could end
+  // up in a case where we report a launch start, but never a completion (e.g.
+  // from package:flutter_work_manager which sometimes creates a FlutterEngine
+  // (and thus configures shorebird) but never runs it. The proper fix for this
+  // is probably to move the launch_start() call to be later in the lifecycle
+  // (when the snapshot is loaded and run, rather than when FlutterEngine is
+  // initialized).  This "hack" will still have a problem where FlutterEngine is
+  // initialized but never run before the app is quit, could still cause us to
+  // suddenly mark-bad a patch that was never actually attempted to launch.
+  if (!init_result) {
+    return false;
+  }
+
+  // Once start_update_thread is called, the next_boot_patch* functions may
+  // change their return values if the shorebird_report_launch_failed
+  // function is called.
+  shorebird_report_launch_start();
+
+  if (shorebird_should_auto_update()) {
+    FML_LOG(INFO) << "Starting Shorebird update";
+    shorebird_start_update_thread();
+  } else {
+    FML_LOG(INFO)
+        << "Shorebird auto_update disabled, not checking for updates.";
+  }
+
+  return true;
+}
+
 void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        flutter::Settings& settings) {
+                        Settings& settings) {
   // cache_path is used for both code_cache and app_storage, as we don't persist
   // any data between releases. args.app_path is appended to
   // the settings.application_library_path vector at this function's call site.

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -110,7 +110,6 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
     // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
     std::vector<const char*> c_paths{};
     c_paths.push_back(args.release_app_library_path.c_str());
-    // Do not modify application_library_path or c_strings will invalidate.
 
     app_parameters.original_libapp_paths = c_paths.data();
     app_parameters.original_libapp_paths_size = c_paths.size();
@@ -125,12 +124,6 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   // instead we will provide examples of how to build a custom update UI
   // within Dart, including updating as part of login, etc.
   // https://github.com/shorebirdtech/shorebird/issues/950
-
-  // We only set the base snapshot on iOS for now.
-  // TODO: this won't compile as we don't have a settings object here.
-  // #if FML_OS_IOS || FML_OS_MACOSX
-  //   SetBaseSnapshot(settings);
-  // #endif
 
   FML_LOG(INFO) << "Checking for active patch";
   char* c_active_path = shorebird_next_boot_patch_path();

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -1,0 +1,223 @@
+
+#include "flutter/shell/common/shorebird/shorebird.h"
+
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "flutter/fml/command_line.h"
+#include "flutter/fml/file.h"
+#include "flutter/fml/macros.h"
+#include "flutter/fml/mapping.h"
+#include "flutter/fml/message_loop.h"
+#include "flutter/fml/native_library.h"
+#include "flutter/fml/paths.h"
+#include "flutter/fml/size.h"
+#include "flutter/lib/ui/plugins/callback_cache.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "flutter/runtime/dart_vm.h"
+#include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+#include "flutter/shell/common/switches.h"
+#include "fml/logging.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+
+#include "third_party/updater/library/include/updater.h"
+
+// Namespaced to avoid Google style warnings.
+namespace flutter {
+
+// Old Android versions (e.g. the v16 ndk Flutter uses) don't always include a
+// getauxval symbol, but the Rust ring crate assumes it exists:
+// https://github.com/briansmith/ring/blob/fa25bf3a7403c9fe6458cb87bd8427be41225ca2/src/cpu/arm.rs#L22
+// It uses it to determine if the CPU supports AES instructions.
+// Making this a weak symbol allows the linker to use a real version instead
+// if it can find one.
+// BoringSSL just reads from procfs instead, which is what we would do if
+// we needed to implement this ourselves.  Implementation looks straightforward:
+// https://lwn.net/Articles/519085/
+// https://github.com/google/boringssl/blob/6ab4f0ae7f2db96d240eb61a5a8b4724e5a09b2f/crypto/cpu_arm_linux.c
+#if defined(__ANDROID__) && defined(__arm__)
+extern "C" __attribute__((weak)) unsigned long getauxval(unsigned long type) {
+  return 0;
+}
+#endif
+
+// TODO(eseidel): I believe we need to leak these or we'll sometimes crash
+// when using the base snapshot in mixed mode.  This likely will not play
+// nicely with multi-engine support and will need to be refactored.
+static fml::RefPtr<const DartSnapshot> vm_snapshot;
+static fml::RefPtr<const DartSnapshot> isolate_snapshot;
+
+void SetBaseSnapshot(Settings& settings) {
+  // These mappings happen to be to static data in the App.framework, but
+  // we still need to seem to hold onto the DartSnapshot objects to keep
+  // the mappings alive.
+  vm_snapshot = DartSnapshot::VMSnapshotFromSettings(settings);
+  isolate_snapshot = DartSnapshot::IsolateSnapshotFromSettings(settings);
+  Shorebird_SetBaseSnapshots(isolate_snapshot->GetDataMapping(),
+                             isolate_snapshot->GetInstructionsMapping(),
+                             vm_snapshot->GetDataMapping(),
+                             vm_snapshot->GetInstructionsMapping());
+}
+
+class FileCallbacksImpl {
+ public:
+  static void* Open();
+  static uintptr_t Read(void* file, uint8_t* buffer, uintptr_t length);
+  static int64_t Seek(void* file, int64_t offset, int32_t whence);
+  static void Close(void* file);
+};
+
+FileCallbacks ShorebirdFileCallbacks() {
+  return {
+      .open = FileCallbacksImpl::Open,
+      .read = FileCallbacksImpl::Read,
+      .seek = FileCallbacksImpl::Seek,
+      .close = FileCallbacksImpl::Close,
+  };
+}
+
+void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
+                        flutter::Settings& settings) {
+  // cache_path is used for both code_cache and app_storage, as we don't persist
+  // any data between releases. args.app_path is appended to
+  // the settings.application_library_path vector at this function's call site.
+  ConfigureShorebird(args.cache_path, args.cache_path, settings,
+                     args.shorebird_yaml_contents, args.app_version,
+                     args.app_build_number);
+}
+
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
+                        Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        const std::string& version_code) {
+  // If you are crashing here, you probably are running Shorebird in a Debug
+  // config, where the AOT snapshot won't be linked into the process, and thus
+  // lookups will fail.  Change your Scheme to Release to fix:
+  // https://github.com/flutter/flutter/wiki/Debugging-the-engine#debugging-ios-builds-with-xcode
+  FML_CHECK(DartSnapshot::VMSnapshotFromSettings(settings))
+      << "XCode Scheme must be set to Release to use Shorebird";
+
+  auto shorebird_updater_dir_name = "shorebird_updater";
+
+  auto code_cache_dir = fml::paths::JoinPaths(
+      {std::move(code_cache_path), shorebird_updater_dir_name});
+  auto app_storage_dir = fml::paths::JoinPaths(
+      {std::move(app_storage_path), shorebird_updater_dir_name});
+
+  fml::CreateDirectory(fml::paths::GetCachesDirectory(),
+                       {shorebird_updater_dir_name},
+                       fml::FilePermission::kReadWrite);
+
+  bool init_result;
+  // Using a block to make AppParameters lifetime explicit.
+  {
+    AppParameters app_parameters;
+    // Combine version and version_code into a single string.
+    // We could also pass these separately through to the updater if needed.
+    auto release_version = version + "+" + version_code;
+    app_parameters.release_version = release_version.c_str();
+    app_parameters.code_cache_dir = code_cache_dir.c_str();
+    app_parameters.app_storage_dir = app_storage_dir.c_str();
+
+    // https://stackoverflow.com/questions/26032039/convert-vectorstring-into-char-c
+    std::vector<const char*> c_paths{};
+    for (const auto& string : settings.application_library_path) {
+      c_paths.push_back(string.c_str());
+    }
+    // Do not modify application_library_path or c_strings will invalidate.
+
+    app_parameters.original_libapp_paths = c_paths.data();
+    app_parameters.original_libapp_paths_size = c_paths.size();
+
+    // shorebird_init copies from app_parameters and shorebirdYaml.
+    init_result = shorebird_init(&app_parameters, ShorebirdFileCallbacks(),
+                                 shorebird_yaml.c_str());
+  }
+
+  // We've decided not to support synchronous updates on launch for now.
+  // It's a terrible user experience (having the app hang on launch) and
+  // instead we will provide examples of how to build a custom update UI
+  // within Dart, including updating as part of login, etc.
+  // https://github.com/shorebirdtech/shorebird/issues/950
+
+  // We only set the base snapshot on iOS for now.
+#if FML_OS_IOS || FML_OS_MACOSX
+  SetBaseSnapshot(settings);
+#endif
+
+  char* c_active_path = shorebird_next_boot_patch_path();
+  if (c_active_path != NULL) {
+    std::string active_path = c_active_path;
+    shorebird_free_string(c_active_path);
+    FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
+
+#if FML_OS_IOS || FML_OS_MACOSX
+    // On iOS we add the patch to the front of the list instead of clearing
+    // the list, to allow dart_shapshot.cc to still find the base snapshot
+    // for the vm isolate.
+    settings.application_library_path.insert(
+        settings.application_library_path.begin(), active_path);
+#else
+    settings.application_library_path.clear();
+    settings.application_library_path.emplace_back(active_path);
+#endif
+  } else {
+    FML_LOG(INFO) << "Shorebird updater: no active patch.";
+  }
+
+  // We are careful only to report a launch start in the case where it's the
+  // first time we've configured shorebird this process. Otherwise we could end
+  // up in a case where we report a launch start, but never a completion (e.g.
+  // from package:flutter_work_manager which sometimes creates a FlutterEngine
+  // (and thus configures shorebird) but never runs it. The proper fix for this
+  // is probably to move the launch_start() call to be later in the lifecycle
+  // (when the snapshot is loaded and run, rather than when FlutterEngine is
+  // initialized).  This "hack" will still have a problem where FlutterEngine is
+  // initialized but never run before the app is quit, could still cause us to
+  // suddenly mark-bad a patch that was never actually attempted to launch.
+  if (!init_result) {
+    return;
+  }
+
+  // Once start_update_thread is called, the next_boot_patch* functions may
+  // change their return values if the shorebird_report_launch_failed
+  // function is called.
+  shorebird_report_launch_start();
+
+  if (shorebird_should_auto_update()) {
+    FML_LOG(INFO) << "Starting Shorebird update";
+    shorebird_start_update_thread();
+  } else {
+    FML_LOG(INFO)
+        << "Shorebird auto_update disabled, not checking for updates.";
+  }
+}
+
+void* FileCallbacksImpl::Open() {
+  return SnapshotsDataHandle::createForSnapshots(*vm_snapshot,
+                                                 *isolate_snapshot)
+      .release();
+}
+
+uintptr_t FileCallbacksImpl::Read(void* file,
+                                  uint8_t* buffer,
+                                  uintptr_t length) {
+  return reinterpret_cast<SnapshotsDataHandle*>(file)->Read(buffer, length);
+}
+
+int64_t FileCallbacksImpl::Seek(void* file, int64_t offset, int32_t whence) {
+  // Currently we only support blob handles.
+  return reinterpret_cast<SnapshotsDataHandle*>(file)->Seek(offset, whence);
+}
+
+void FileCallbacksImpl::Close(void* file) {
+  delete reinterpret_cast<SnapshotsDataHandle*>(file);
+}
+
+}  // namespace flutter

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -21,7 +21,6 @@
 #include "flutter/shell/common/shorebird/snapshots_data_handle.h"
 #include "flutter/shell/common/switches.h"
 #include "fml/logging.h"
-#include "shell/platform/embedder/embedder.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 
 #include "third_party/updater/library/include/updater.h"
@@ -163,16 +162,6 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   }
 
   return true;
-}
-
-void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        Settings& settings) {
-  // cache_path is used for both code_cache and app_storage, as we don't persist
-  // any data between releases. args.app_path is appended to
-  // the settings.application_library_path vector at this function's call site.
-  ConfigureShorebird(args.cache_path, args.cache_path, settings,
-                     args.shorebird_yaml_contents, args.app_version,
-                     args.app_build_number);
 }
 
 void ConfigureShorebird(std::string code_cache_path,

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -54,8 +54,13 @@ void SetBaseSnapshot(Settings& settings) {
   // These mappings happen to be to static data in the App.framework, but
   // we still need to seem to hold onto the DartSnapshot objects to keep
   // the mappings alive.
+  FML_LOG(INFO) << "Setting base snapshots";
+  FML_LOG(INFO) << "getting vm snapshot";
+  // segfaults on the next line
   vm_snapshot = DartSnapshot::VMSnapshotFromSettings(settings);
+  FML_LOG(INFO) << "getting isolate snapshot";
   isolate_snapshot = DartSnapshot::IsolateSnapshotFromSettings(settings);
+  FML_LOG(INFO) << "Calling Shorebird_SetBaseSnapshots";
   Shorebird_SetBaseSnapshots(isolate_snapshot->GetDataMapping(),
                              isolate_snapshot->GetInstructionsMapping(),
                              vm_snapshot->GetDataMapping(),

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -14,7 +14,6 @@
 #include "flutter/fml/message_loop.h"
 #include "flutter/fml/native_library.h"
 #include "flutter/fml/paths.h"
-#include "flutter/fml/size.h"
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_snapshot.h"
 #include "flutter/runtime/dart_vm.h"

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -6,12 +6,39 @@
 
 namespace flutter {
 
+struct ReleaseVersion {
+  std::string version;
+  std::string build_number;
+};
+
+struct ShorebirdConfigArgs {
+  std::string code_cache_path;
+  std::string app_storage_path;
+  std::string release_app_library_path;
+  std::string shorebird_yaml;
+  ReleaseVersion release_version;
+
+  ShorebirdConfigArgs(std::string code_cache_path,
+                      std::string app_storage_path,
+                      std::string release_app_library_path,
+                      std::string shorebird_yaml,
+                      ReleaseVersion release_version)
+      : code_cache_path(code_cache_path),
+        app_storage_path(app_storage_path),
+        release_app_library_path(release_app_library_path),
+        shorebird_yaml(shorebird_yaml),
+        release_version(release_version) {}
+};
+
+bool ConfigureShorebird(const ShorebirdConfigArgs& args,
+                        std::string& patch_path);
+
 void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        flutter::Settings& settings);
+                        Settings& settings);
 
 void ConfigureShorebird(std::string code_cache_path,
                         std::string app_storage_path,
-                        flutter::Settings& settings,
+                        Settings& settings,
                         const std::string& shorebird_yaml,
                         const std::string& version,
                         const std::string& version_code);

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -2,7 +2,6 @@
 #define FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_
 
 #include "flutter/common/settings.h"
-#include "shell/platform/embedder/embedder.h"
 
 namespace flutter {
 
@@ -32,9 +31,6 @@ struct ShorebirdConfigArgs {
 
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path);
-
-void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        Settings& settings);
 
 void ConfigureShorebird(std::string code_cache_path,
                         std::string app_storage_path,

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -1,0 +1,21 @@
+#ifndef FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_
+#define FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_
+
+#include "flutter/common/settings.h"
+#include "shell/platform/embedder/embedder.h"
+
+namespace flutter {
+
+void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
+                        flutter::Settings& settings);
+
+void ConfigureShorebird(std::string code_cache_path,
+                        std::string app_storage_path,
+                        flutter::Settings& settings,
+                        const std::string& shorebird_yaml,
+                        const std::string& version,
+                        const std::string& version_code);
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_SHOREBIRD_SHOREBIRD_H_

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -29,6 +29,8 @@ struct ShorebirdConfigArgs {
         release_version(release_version) {}
 };
 
+void SetBaseSnapshot(Settings& settings);
+
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path);
 

--- a/shell/common/shorebird/snapshots_data_handle.cc
+++ b/shell/common/shorebird/snapshots_data_handle.cc
@@ -1,0 +1,144 @@
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+
+#include "third_party/dart/runtime/include/dart_native_api.h"
+
+namespace flutter {
+
+static std::unique_ptr<fml::Mapping> DataMapping(const DartSnapshot& snapshot) {
+  auto ptr = snapshot.GetDataMapping();
+  return std::make_unique<fml::NonOwnedMapping>(ptr,
+                                                Dart_SnapshotDataSize(ptr));
+}
+
+static std::unique_ptr<fml::Mapping> InstructionsMapping(
+    const DartSnapshot& snapshot) {
+  auto ptr = snapshot.GetInstructionsMapping();
+  return std::make_unique<fml::NonOwnedMapping>(ptr,
+                                                Dart_SnapshotInstrSize(ptr));
+}
+
+// The size of the snapshot data is the sum of the sizes of the blobs.
+size_t SnapshotsDataHandle::FullSize() const {
+  size_t size = 0;
+  for (const auto& blob : blobs_) {
+    size += blob->GetSize();
+  }
+  return size;
+}
+
+// The offset into the snapshots data blobs as though they were a single
+// contiguous buffer.
+size_t SnapshotsDataHandle::AbsoluteOffsetForIndex(BlobsIndex index) {
+  if (index.blob >= blobs_.size()) {
+    FML_LOG(WARNING) << "Blob index " << index.blob
+                     << " is larger than the number of blobs (" << blobs_.size()
+                     << "). Returning full size (" << FullSize() << ")";
+    return FullSize();
+  }
+  if (index.offset > blobs_[index.blob]->GetSize()) {
+    FML_LOG(WARNING) << "Offset for blob " << index.blob << " (" << index.offset
+                     << ") is larger than the blob size ("
+                     << blobs_[index.blob]->GetSize()
+                     << "). Returning index start of next blob";
+    return AbsoluteOffsetForIndex({index.blob + 1, 0});
+  }
+  size_t offset = 0;
+  for (size_t i = 0; i < index.blob; i++) {
+    offset += blobs_[i]->GetSize();
+  }
+  offset += index.offset;
+  return offset;
+}
+
+BlobsIndex SnapshotsDataHandle::IndexForAbsoluteOffset(int64_t offset,
+                                                       BlobsIndex start_index) {
+  size_t start_offset = AbsoluteOffsetForIndex(start_index);
+  if (offset < 0) {
+    if ((size_t)abs(offset) > start_offset) {
+      FML_LOG(WARNING)
+          << "Offset is before the beginning of SnapshotsData. Returning 0, 0";
+      return {0, 0};
+    }
+  } else if (offset + start_offset >= FullSize()) {
+    FML_LOG(WARNING) << "Target offset is past the end of SnapshotsData ("
+                     << offset + start_offset << ", blobs size:" << FullSize()
+                     << "). Returning last blob index and offset";
+    return {blobs_.size(), blobs_.back()->GetSize()};
+  }
+
+  size_t dest_offset = start_offset + offset;
+  BlobsIndex index = {0, 0};
+  for (const auto& blob : blobs_) {
+    if (dest_offset < blob->GetSize()) {
+      // The remaining offset is within this blob.
+      index.offset = dest_offset;
+      break;
+    }
+
+    index.blob++;
+    dest_offset -= blob->GetSize();
+  }
+  return index;
+}
+
+std::unique_ptr<SnapshotsDataHandle> SnapshotsDataHandle::createForSnapshots(
+    const DartSnapshot& vm_snapshot,
+    const DartSnapshot& isolate_snapshot) {
+  // This needs to match the order in which the blobs are written out in
+  // analyze_snapshot --dump_blobs
+  std::vector<std::unique_ptr<fml::Mapping>> blobs;
+  blobs.push_back(DataMapping(vm_snapshot));
+  blobs.push_back(DataMapping(isolate_snapshot));
+  blobs.push_back(InstructionsMapping(vm_snapshot));
+  blobs.push_back(InstructionsMapping(isolate_snapshot));
+  return std::make_unique<SnapshotsDataHandle>(std::move(blobs));
+}
+
+uintptr_t SnapshotsDataHandle::Read(uint8_t* buffer, uintptr_t length) {
+  uintptr_t bytes_read = 0;
+  // Copy current blob from current offset and possibly into the next blob
+  // until we have read length bytes.
+  while (bytes_read < length) {
+    if (current_index_.blob >= blobs_.size()) {
+      // We have read all blobs.
+      break;
+    }
+    intptr_t remaining_blob_length =
+        blobs_[current_index_.blob]->GetSize() - current_index_.offset;
+    if (remaining_blob_length <= 0) {
+      // We have read all bytes in this blob.
+      current_index_.blob++;
+      current_index_.offset = 0;
+      continue;
+    }
+    intptr_t bytes_to_read = fmin(length - bytes_read, remaining_blob_length);
+    memcpy(buffer + bytes_read,
+           blobs_[current_index_.blob]->GetMapping() + current_index_.offset,
+           bytes_to_read);
+    bytes_read += bytes_to_read;
+    current_index_.offset += bytes_to_read;
+  }
+
+  return bytes_read;
+}
+
+int64_t SnapshotsDataHandle::Seek(int64_t offset, int32_t whence) {
+  BlobsIndex start_index;
+  switch (whence) {
+    case SEEK_CUR:
+      start_index = current_index_;
+      break;
+    case SEEK_SET:
+      start_index = {0, 0};
+      break;
+    case SEEK_END:
+      start_index = {blobs_.size(), blobs_.back()->GetSize()};
+      break;
+    default:
+      FML_CHECK(false) << "Unrecognized whence value in Seek: " << whence;
+  }
+  current_index_ = IndexForAbsoluteOffset(offset, start_index);
+  return current_index_.offset;
+}
+
+}  // namespace flutter

--- a/shell/common/shorebird/snapshots_data_handle.h
+++ b/shell/common/shorebird/snapshots_data_handle.h
@@ -1,0 +1,47 @@
+#ifndef FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_
+#define FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_
+
+#include "flutter/fml/file.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "third_party/dart/runtime/include/dart_tools_api.h"
+
+namespace flutter {
+
+// An offset into an indexed collection of buffers. blob is the index of the
+// buffer, and offset is the offset into that buffer.
+struct BlobsIndex {
+  size_t blob;
+  size_t offset;
+};
+
+// Implements a POSIX file I/O interface which allows us to provide the four
+// data blobs of a Dart snapshot (vm_data, vm_instructions, isolate_data,
+// isolate_instructions) to Rust as though it were a single piece of memory.
+class SnapshotsDataHandle {
+ public:
+  // This would ideally be private, but we need to be able to call it from the
+  // static createForSnapshots method.
+  explicit SnapshotsDataHandle(std::vector<std::unique_ptr<fml::Mapping>> blobs)
+      : blobs_(std::move(blobs)) {}
+
+  static std::unique_ptr<SnapshotsDataHandle> createForSnapshots(
+      const DartSnapshot& vm_snapshot,
+      const DartSnapshot& isolate_snapshot);
+
+  uintptr_t Read(uint8_t* buffer, uintptr_t length);
+  int64_t Seek(int64_t offset, int32_t whence);
+
+  // The sum of all the blobs' sizes.
+  size_t FullSize() const;
+
+ private:
+  size_t AbsoluteOffsetForIndex(BlobsIndex index);
+  BlobsIndex IndexForAbsoluteOffset(int64_t offset, BlobsIndex startIndex);
+
+  BlobsIndex current_index_ = {0, 0};
+  std::vector<std::unique_ptr<fml::Mapping>> blobs_;
+};
+
+}  // namespace flutter
+
+#endif  // FLUTTER_SHELL_COMMON_SHOREBIRD_SNAPSHOTS_DATA_HANDLE_H_

--- a/shell/common/shorebird/snapshots_data_handle_unittests.cc
+++ b/shell/common/shorebird/snapshots_data_handle_unittests.cc
@@ -1,0 +1,177 @@
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "flutter/shell/common/shorebird/snapshots_data_handle.h"
+
+#include "flutter/fml/mapping.h"
+#include "flutter/runtime/dart_snapshot.h"
+#include "flutter/testing/testing.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "testing/fixture_test.h"
+
+namespace flutter {
+namespace testing {
+
+std::unique_ptr<SnapshotsDataHandle> MakeHandle(
+    std::vector<std::string>& blobs) {
+  // Map the strings into non-owned mappings:
+  std::vector<std::unique_ptr<fml::Mapping>> mappings = {};
+  for (auto& blob : blobs) {
+    std::unique_ptr<fml::Mapping> mapping =
+        std::make_unique<fml::NonOwnedMapping>(
+            reinterpret_cast<const uint8_t*>(blob.data()), blob.size());
+    mappings.push_back(std::move(mapping));
+  }
+  auto handle =
+      std::make_unique<flutter::SnapshotsDataHandle>(std::move(mappings));
+  return handle;
+}
+
+TEST(SnapshotsDataHandle, Read) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 12;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+  EXPECT_EQ(buffer[2], 'c');
+  EXPECT_EQ(buffer[3], 'd');
+  EXPECT_EQ(buffer[4], 'e');
+  EXPECT_EQ(buffer[5], 'f');
+
+  // Only the first 6 bytes should have been read.
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, ReadAfterSeekWithPositiveOffset) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  blobs_handle->Seek(4, SEEK_CUR);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'e');
+  EXPECT_EQ(buffer[1], 'f');
+  EXPECT_EQ(buffer[2], 'g');
+  EXPECT_EQ(buffer[3], 'h');
+  EXPECT_EQ(buffer[4], 'i');
+  EXPECT_EQ(buffer[5], 'j');
+
+  // Only the first 6 bytes should have been read.
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, ReadAfterSeekWithNegativeOffset) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  blobs_handle->Read(buffer, 5);
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+  EXPECT_EQ(buffer[2], 'c');
+  EXPECT_EQ(buffer[3], 'd');
+  EXPECT_EQ(buffer[4], 'e');
+  EXPECT_EQ(buffer[5], 0);
+
+  // Reset buffer
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Read 5, seeked back 4, should start reading at offset 1 ('b')
+  blobs_handle->Seek(-4, SEEK_CUR);
+  blobs_handle->Read(buffer, 6);
+
+  EXPECT_EQ(buffer[0], 'b');
+  EXPECT_EQ(buffer[1], 'c');
+  EXPECT_EQ(buffer[2], 'd');
+  EXPECT_EQ(buffer[3], 'e');
+  EXPECT_EQ(buffer[4], 'f');
+  EXPECT_EQ(buffer[5], 'g');
+  EXPECT_EQ(buffer[6], 0);
+}
+
+TEST(SnapshotsDataHandle, SeekPastEnd) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 1 past the end
+  blobs_handle->Seek(blobs_handle->FullSize() + 1, SEEK_CUR);
+
+  // Seek back 2 bytes and read 2 bytes
+  blobs_handle->Seek(-2, SEEK_CUR);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'k');
+  EXPECT_EQ(buffer[1], 'l');
+}
+
+TEST(SnapshotsDataHandle, SeekBeforeBeginning) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek before the start of the blobs and read the first 2 bytes.
+  blobs_handle->Seek(-2, SEEK_CUR);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'a');
+  EXPECT_EQ(buffer[1], 'b');
+}
+
+TEST(SnapshotsDataHandle, SeekFromBeginning) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 10 bytes from current (the beginning)
+  blobs_handle->Seek(10, SEEK_CUR);
+
+  // Seek 2 bytes from the beginning and read 2 bytes
+  blobs_handle->Seek(2, SEEK_SET);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'c');
+  EXPECT_EQ(buffer[1], 'd');
+}
+
+TEST(SnapshotsDataHandle, SeekFromEnd) {
+  std::vector<std::string> blobs = {"abc", "def", "ghi", "jkl"};
+  std::unique_ptr<SnapshotsDataHandle> blobs_handle = MakeHandle(blobs);
+
+  const size_t buffer_size = 20;
+  uint8_t buffer[buffer_size];
+  std::fill(buffer, buffer + buffer_size, 0);
+
+  // Seek 2 bytes from the end and read 2 bytes
+  blobs_handle->Seek(-2, SEEK_END);
+  blobs_handle->Read(buffer, 2);
+
+  EXPECT_EQ(buffer[0], 'k');
+  EXPECT_EQ(buffer[1], 'l');
+}
+
+}  // namespace testing
+}  // namespace flutter

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -159,6 +159,7 @@ source_set("flutter_shell_native_src") {
     "//flutter/runtime",
     "//flutter/runtime:libdart",
     "//flutter/shell/common",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/android/context",
     "//flutter/shell/platform/android/external_view_embedder",
     "//flutter/shell/platform/android/jni",
@@ -172,6 +173,8 @@ source_set("flutter_shell_native_src") {
 
   public_configs = [ "//flutter:config" ]
 
+  include_dirs = [ "//flutter/updater" ]
+
   defines = []
 
   libs = [
@@ -179,6 +182,23 @@ source_set("flutter_shell_native_src") {
     "EGL",
     "GLESv2",
   ]
+  if (target_cpu == "arm") {
+    libs += [ "//third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
+  } else if (target_cpu == "arm64") {
+    libs += [
+      "//third_party/updater/target/aarch64-linux-android/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x64") {
+    libs += [
+      "//third_party/updater/target/x86_64-linux-android/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x86") {
+    libs += [
+      "//third_party/updater/target/i686-linux-android/release/libupdater.a",
+    ]
+  } else {
+    assert(false, "Unsupported target_cpu")
+  }
 }
 
 action("gen_android_build_config_java") {
@@ -726,12 +746,23 @@ if (target_cpu != "x86") {
 
   # TODO(godofredoc): Remove gen_snapshot and rename new_gen_snapshot when v2 migration is complete.
   # BUG: https://github.com/flutter/flutter/issues/105351
+  # This has a somewhat misleading name. We (shorebird) have updated this target
+  # to include analyze_snapshot as well as gen_snapshot. Because this target is
+  # used elsewhere in the toolchain, we did not rename it.
   zip_bundle("new_gen_snapshot") {
     gen_snapshot_bin = "gen_snapshot"
     gen_snapshot_out_dir =
         get_label_info("$dart_src/runtime/bin:gen_snapshot($host_toolchain)",
                        "root_out_dir")
     gen_snapshot_path = rebase_path("$gen_snapshot_out_dir/$gen_snapshot_bin")
+
+    analyze_snapshot_bin = "analyze_snapshot"
+    analyze_snapshot_out_dir =
+        get_label_info(
+            "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+            "root_out_dir")
+    analyze_snapshot_path =
+        rebase_path("$analyze_snapshot_out_dir/$analyze_snapshot_bin")
 
     if (host_os == "linux") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/linux-x64.zip"
@@ -741,6 +772,8 @@ if (target_cpu != "x86") {
       output = "$android_zip_archive_dir/$full_platform_name-$flutter_runtime_mode/windows-x64.zip"
       gen_snapshot_bin = "gen_snapshot.exe"
       gen_snapshot_path = rebase_path("$root_out_dir/$gen_snapshot_bin")
+      analyze_snapshot_bin = "analyze_snapshot.exe"
+      analyze_snapshot_path = rebase_path("$root_out_dir/$analyze_snapshot_bin")
     }
 
     files = [
@@ -748,9 +781,16 @@ if (target_cpu != "x86") {
         source = gen_snapshot_path
         destination = gen_snapshot_bin
       },
+      {
+        source = analyze_snapshot_path
+        destination = analyze_snapshot_bin
+      },
     ]
 
-    deps = [ "$dart_src/runtime/bin:gen_snapshot($host_toolchain)" ]
+    deps = [
+      "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)",
+      "$dart_src/runtime/bin:gen_snapshot($host_toolchain)",
+    ]
 
     if (host_os == "mac") {
       deps += [ ":android_entitlement_config" ]
@@ -764,7 +804,7 @@ if (target_cpu != "x86") {
   }
 }
 
-if (host_os == "linux" && (target_cpu == "x64" || target_cpu == "arm64")) {
+if (target_cpu == "arm64") {
   zip_bundle("analyze_snapshot") {
     deps = [ "$dart_src/runtime/bin:analyze_snapshot($host_toolchain)" ]
 

--- a/shell/platform/android/android_exports.lst
+++ b/shell/platform/android/android_exports.lst
@@ -17,6 +17,7 @@
     shorebird_free_string;
     shorebird_free_update_result;
     shorebird_check_for_downloadable_update;
+    shorebird_check_for_update;
     shorebird_update;
     shorebird_update_with_result;
     shorebird_next_boot_patch_number;

--- a/shell/platform/android/android_exports.lst
+++ b/shell/platform/android/android_exports.lst
@@ -11,6 +11,16 @@
     _binary_icudtl_dat_size;
     InternalFlutterGpu*;
     kInternalFlutterGpu*;
+    shorebird_init;
+    shorebird_active_path;
+    shorebird_active_patch_number;
+    shorebird_free_string;
+    shorebird_free_update_result;
+    shorebird_check_for_downloadable_update;
+    shorebird_update;
+    shorebird_update_with_result;
+    shorebird_next_boot_patch_number;
+    shorebird_current_boot_patch_number;
   local:
     *;
 };

--- a/shell/platform/android/flutter_main.cc
+++ b/shell/platform/android/flutter_main.cc
@@ -21,6 +21,7 @@
 #include "flutter/lib/ui/plugins/callback_cache.h"
 #include "flutter/runtime/dart_vm.h"
 #include "flutter/shell/common/shell.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/android/android_context_vk_impeller.h"
 #include "flutter/shell/platform/android/context/android_context.h"
@@ -29,6 +30,8 @@
 #include "impeller/toolkit/android/proc_table.h"
 #include "third_party/dart/runtime/include/dart_tools_api.h"
 #include "txt/platform.h"
+
+#include "third_party/updater/library/include/updater.h"
 
 namespace flutter {
 
@@ -72,6 +75,9 @@ void FlutterMain::Init(JNIEnv* env,
                        jstring kernelPath,
                        jstring appStoragePath,
                        jstring engineCachesPath,
+                       jstring shorebirdYaml,
+                       jstring version,
+                       jstring versionCode,
                        jlong initTimeMillis) {
   std::vector<std::string> args;
   args.push_back("flutter");
@@ -120,8 +126,18 @@ void FlutterMain::Init(JNIEnv* env,
   flutter::DartCallbackCache::SetCachePath(
       fml::jni::JavaStringToString(env, appStoragePath));
 
-  fml::paths::InitializeAndroidCachesPath(
-      fml::jni::JavaStringToString(env, engineCachesPath));
+  auto code_cache_path = fml::jni::JavaStringToString(env, engineCachesPath);
+  auto app_storage_path = fml::jni::JavaStringToString(env, appStoragePath);
+  fml::paths::InitializeAndroidCachesPath(code_cache_path);
+
+#if FLUTTER_RELEASE
+  std::string shorebird_yaml = fml::jni::JavaStringToString(env, shorebirdYaml);
+  std::string version_string = fml::jni::JavaStringToString(env, version);
+  std::string version_code_string =
+      fml::jni::JavaStringToString(env, versionCode);
+  ConfigureShorebird(code_cache_path, app_storage_path, settings,
+                     shorebird_yaml, version_string, version_code_string);
+#endif
 
   flutter::DartCallbackCache::LoadCacheFromDisk();
 
@@ -211,6 +227,7 @@ bool FlutterMain::Register(JNIEnv* env) {
       {
           .name = "nativeInit",
           .signature = "(Landroid/content/Context;[Ljava/lang/String;Ljava/"
+                       "lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/"
                        "lang/String;Ljava/lang/String;Ljava/lang/String;J)V",
           .fnPtr = reinterpret_cast<void*>(&Init),
       },

--- a/shell/platform/android/flutter_main.h
+++ b/shell/platform/android/flutter_main.h
@@ -39,6 +39,9 @@ class FlutterMain {
                    jstring kernelPath,
                    jstring appStoragePath,
                    jstring engineCachesPath,
+                   jstring shorebirdYaml,
+                   jstring version,
+                   jstring versionCode,
                    jlong initTimeMillis);
 
   void SetupDartVMServiceUriCallback(JNIEnv* env);

--- a/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
+++ b/shell/platform/android/io/flutter/embedding/engine/FlutterJNI.java
@@ -7,6 +7,8 @@ package io.flutter.embedding.engine;
 import static io.flutter.Build.API_LEVELS;
 
 import android.content.Context;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.ColorSpace;
@@ -40,7 +42,10 @@ import io.flutter.util.Preconditions;
 import io.flutter.view.AccessibilityBridge;
 import io.flutter.view.FlutterCallbackInformation;
 import io.flutter.view.TextureRegistry;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.ref.WeakReference;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -177,6 +182,9 @@ public class FlutterJNI {
       @Nullable String bundlePath,
       @NonNull String appStoragePath,
       @NonNull String engineCachesPath,
+      @Nullable String shorebirdYaml,
+      @Nullable String version,
+      @Nullable String versionCode,
       long initTimeMillis);
 
   /**
@@ -202,8 +210,46 @@ public class FlutterJNI {
       Log.w(TAG, "FlutterJNI.init called more than once");
     }
 
+    String version = null;
+    String versionCode = null;
+    try {
+      PackageInfo packageInfo =
+          context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+      version = packageInfo.versionName;
+      if (Build.VERSION.SDK_INT >= API_LEVELS.API_28) {
+        versionCode = String.valueOf(packageInfo.getLongVersionCode());
+      } else {
+        versionCode = String.valueOf(packageInfo.versionCode);
+      }
+    } catch (PackageManager.NameNotFoundException e) {
+      Log.e(TAG, "Failed to read app version.  Shorebird updater can't run.", e);
+    }
+
+    String shorebirdYaml = null;
+    try {
+      InputStream yaml = context.getAssets().open("flutter_assets/shorebird.yaml");
+      BufferedReader r = new BufferedReader(new InputStreamReader(yaml));
+      StringBuilder total = new StringBuilder();
+      for (String line; (line = r.readLine()) != null; ) {
+        total.append(line).append('\n');
+      }
+      shorebirdYaml = total.toString();
+      Log.d(TAG, "shorebird.yaml: " + shorebirdYaml);
+    } catch (IOException e) {
+      Log.e(TAG, "Failed to load shorebird.yaml", e);
+      Log.e(TAG, "Did you remember to include shorebird.yaml in your pubspec.yaml's assets?");
+    }
+
     FlutterJNI.nativeInit(
-        context, args, bundlePath, appStoragePath, engineCachesPath, initTimeMillis);
+        context,
+        args,
+        bundlePath,
+        appStoragePath,
+        engineCachesPath,
+        shorebirdYaml,
+        version,
+        versionCode,
+        initTimeMillis);
     FlutterJNI.initCalled = true;
   }
 

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -52,6 +52,7 @@ source_set("flutter_framework_source_arc") {
   deps = [
     ":flutter_framework_source",
     "//flutter/fml",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/third_party/icu",
@@ -202,9 +203,11 @@ source_set("flutter_framework_source") {
   }
 
   deps += [
+    "$dart_src/runtime/bin:elf_loader",
     "//flutter/fml",
     "//flutter/runtime",
     "//flutter/shell/common",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/embedder:embedder_as_internal_library",
@@ -216,6 +219,17 @@ source_set("flutter_framework_source") {
     ":ios_gpu_configuration_config",
     "//flutter:config",
   ]
+
+  if (target_cpu == "arm64") {
+    libs = [
+      "//third_party/updater/target/aarch64-apple-ios/release/libupdater.a",
+    ]
+  } else if (target_cpu == "x64") {
+    libs =
+        [ "//third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
+  } else {
+    assert(false, "Unsupported target_cpu")
+  }
 
   frameworks = [
     "AudioToolbox.framework",

--- a/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterDartProject.mm
@@ -12,6 +12,8 @@
 #include <syslog.h>
 
 #include "flutter/common/constants.h"
+#include "flutter/fml/paths.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #import "flutter/shell/platform/darwin/common/command_line.h"
 
@@ -96,10 +98,12 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
   }
 
   if (flutter::DartVM::IsRunningPrecompiledCode()) {
+    NSLog(@"SANITY CHECK: Running precompiled code.");
     if (hasExplicitBundle) {
       NSString* executablePath = bundle.executablePath;
       if ([[NSFileManager defaultManager] fileExistsAtPath:executablePath]) {
         settings.application_library_path.push_back(executablePath.UTF8String);
+        NSLog(@"Using precompiled library from %@", executablePath);
       }
     }
 
@@ -111,6 +115,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         NSString* executablePath = [NSBundle bundleWithPath:libraryPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using library from %@", libraryPath);
         }
       }
     }
@@ -125,6 +130,7 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
             [NSBundle bundleWithPath:applicationFrameworkPath].executablePath;
         if (executablePath.length > 0) {
           settings.application_library_path.push_back(executablePath.UTF8String);
+          NSLog(@"Using App.framework from %@", applicationFrameworkPath);
         }
       }
     }
@@ -154,6 +160,33 @@ flutter::Settings FLTDefaultSettingsForBundle(NSBundle* bundle, NSProcessInfo* p
         }
       }
     }
+  }
+
+  NSString* assetsPath = [NSString stringWithUTF8String:settings.assets_path.c_str()];
+  NSLog(@"ASSET PATH %@", assetsPath);
+
+  // FIXME: This may not be the correct path (e.g., should it include the organization id?)
+  // See
+  // https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html#//apple_ref/doc/uid/TP40010672-CH2-SW13
+  // /private/var/mobile/Containers/Data/Application/264477BF-6E38-47C9-AAD9-532BB842F197/Library/Application
+  // Support/shorebird/shorebird_updater
+  std::string cache_path =
+      fml::paths::JoinPaths({getenv("HOME"), "Library/Application Support/shorebird"});
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* appVersion = [mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  if (shorebirdYamlContents != nil) {
+    // Note: we intentionally pass cache_path twice. We provide two different directories
+    //   to ConfigureShorebird because Android differentiates between data that persists
+    //   between releases and data that does not. iOS does not make this distinction.
+    flutter::ConfigureShorebird(cache_path, cache_path, settings, shorebirdYamlContents.UTF8String,
+                                appVersion.UTF8String, appBuildNumber.UTF8String);
+  } else {
+    NSLog(@"Failed to find shorebird.yaml, not starting updater.");
   }
 
   // Domain network configuration

--- a/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
+++ b/shell/platform/darwin/ios/framework/Source/FlutterViewController.mm
@@ -34,6 +34,8 @@
 #import "flutter/shell/platform/embedder/embedder.h"
 #import "flutter/third_party/spring_animation/spring_animation.h"
 
+#import <third_party/dart/runtime/vm/cpu.h>
+
 static constexpr int kMicrosecondsPerSecond = 1000 * 1000;
 static constexpr CGFloat kScrollViewContentSize = 2.0;
 
@@ -238,6 +240,8 @@ typedef struct MouseState {
   if (!project) {
     project = [[[FlutterDartProject alloc] init] autorelease];
   }
+  FML_LOG(INFO) << "CPU::Id(): " << dart::CPU::Id();
+
   FlutterView.forceSoftwareRendering = project.settings.enable_software_rendering;
   _weakFactory = std::make_unique<fml::WeakNSObjectFactory<FlutterViewController>>(self);
   auto engine = fml::scoped_nsobject<FlutterEngine>{[[FlutterEngine alloc]

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -123,6 +123,7 @@ source_set("flutter_framework_source") {
     ":macos_gpu_configuration",
     "//flutter/flow:flow",
     "//flutter/fml",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/common:common_cpp_accessibility",
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -127,6 +127,7 @@ source_set("flutter_framework_source") {
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
+    "//flutter/shell/platform/darwin/common",
     "//flutter/shell/platform/darwin/common:availability_version_check",
     "//flutter/shell/platform/darwin/common:framework_common",
     "//flutter/shell/platform/darwin/graphics:graphics",

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "flutter/shell/platform/darwin/macos/framework/Headers/FlutterEngine.h"
+#include <Foundation/Foundation.h>
 #import "flutter/shell/platform/darwin/macos/framework/Source/FlutterEngine_Internal.h"
 
 #include <algorithm>
@@ -11,6 +12,7 @@
 
 #include "flutter/common/constants.h"
 #include "flutter/fml/paths.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -703,6 +705,44 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
+
+  NSLog(@"Starting to configure shorebird");
+  {
+    NSString* bundlePath =
+        [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                     URLByAppendingPathComponent:@"App.framework"]] bundlePath];
+    bundlePath = [bundlePath stringByAppendingString:@"/App"];
+    NSString* assetsPath = _project.assetsPath;
+    NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                      relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+    NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                               encoding:NSUTF8StringEncoding
+                                                                  error:nil];
+    NSString* appVersion =
+        [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+    NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+
+    std::string cache_path =
+        fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
+
+    NSLog(@"Constructing shorebird args");
+    flutter::ShorebirdConfigArgs shorebirdArgs(cache_path, cache_path,
+                                               std::string(bundlePath.UTF8String),
+                                               std::string(shorebirdYamlContents.UTF8String),
+                                               {
+                                                   std::string(appVersion.UTF8String),
+                                                   std::string(appBuildNumber.UTF8String),
+                                               });
+    NSLog(@"Constructed shorebird args");
+    std::string _patch_path = "";
+    NSLog(@"calling configure shorebird");
+    if (!flutter::ConfigureShorebird(shorebirdArgs, _patch_path)) {
+      NSLog(@"Failed to configure shorebird");
+    }
+    _embedderAPI.ShorebirdSetBaseSnapshot(_aotData);
+    NSLog(@"Done configuring shorebird!");
+  }
+
   FlutterEngineResult result = _embedderAPI.Initialize(
       FLUTTER_ENGINE_VERSION, &rendererConfig, &flutterArguments, (__bridge void*)(self), &_engine);
   if (result != kSuccess) {

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "flutter/common/constants.h"
+#include "flutter/fml/paths.h"
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -678,6 +679,28 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
     [engine onVSync:baton];
   };
+
+  NSString* bundlePath =
+      [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                   URLByAppendingPathComponent:@"App.framework"]] bundlePath];
+  bundlePath = [bundlePath stringByAppendingString:@"/App"];
+  flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
+  NSString* assetsPath = _project.assetsPath;
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  NSString* appVersion =
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
+  flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
+
+  std::string cache_path =
+      fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
+  flutterArguments.shorebird_args.cache_path = cache_path.c_str();
+  flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
   FlutterEngineResult result = _embedderAPI.Initialize(

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -682,31 +682,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     [engine onVSync:baton];
   };
 
-  NSString* bundlePath =
-      [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
-                                   URLByAppendingPathComponent:@"App.framework"]] bundlePath];
-  bundlePath = [bundlePath stringByAppendingString:@"/App"];
-  flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
-  NSString* assetsPath = _project.assetsPath;
-  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
-                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
-  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
-                                                             encoding:NSUTF8StringEncoding
-                                                                error:nil];
-  NSString* appVersion =
-      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-  NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
-  flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
-  flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
-
-  std::string cache_path =
-      fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
-  flutterArguments.shorebird_args.cache_path = cache_path.c_str();
-  flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
-
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
 
-  NSLog(@"Starting to configure shorebird");
   {
     NSString* bundlePath =
         [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
@@ -739,7 +716,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
     if (!flutter::ConfigureShorebird(shorebirdArgs, _patch_path)) {
       NSLog(@"Failed to configure shorebird");
     }
-    _embedderAPI.ShorebirdSetBaseSnapshot(_aotData);
     NSLog(@"Done configuring shorebird!");
   }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -110,6 +110,7 @@ template("embedder_source_set") {
       "//flutter/lib/ui",
       "//flutter/runtime:libdart",
       "//flutter/shell/common",
+      "//flutter/shell/common/shorebird",
       "//flutter/skia",
       "//flutter/third_party/tonic",
     ]

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2306,18 +2306,6 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         "Could not infer the Flutter project to run from given arguments.");
   }
 
-  // FIXME: This is probably the wrong place to call ConfigureShorebird, as
-  // some platforms (i.e., Windows) need to to swap out the app path before
-  // this point.
-  // Begin shorebird
-  // #if FML_OS_MACOSX
-  //   if (args->shorebird_args.shorebird_yaml_contents) {
-  //     settings.application_library_path.push_back(args->shorebird_args.app_path);
-  //     flutter::ConfigureShorebird(args->shorebird_args, settings);
-  //   }
-  // #endif
-  // End shorebird
-
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(
       std::move(thread_host),               //

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2306,13 +2306,16 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         "Could not infer the Flutter project to run from given arguments.");
   }
 
+  // FIXME: This is probably the wrong place to call ConfigureShorebird, as
+  // some platforms (i.e., Windows) need to to swap out the app path before
+  // this point.
   // Begin shorebird
+#if FML_OS_MACOSX
   if (args->shorebird_args.shorebird_yaml_contents) {
     settings.application_library_path.push_back(args->shorebird_args.app_path);
     flutter::ConfigureShorebird(args->shorebird_args, settings);
-  } else {
-    FML_LOG(INFO) << "[shorebird] No shorebird YAML contents provided.";
   }
+#endif
   // End shorebird
 
   // Create the engine but don't launch the shell or run the root isolate.

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2307,7 +2307,9 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   }
 
 #if SHOREBIRD_USES_MIXED_MODE
+  FML_LOG(INFO) << "Using mixed mode, setting base snapshot";
   flutter::SetBaseSnapshot(settings);
+  FML_LOG(INFO) << "Set base snapshot";
 #endif
 
   // Create the engine but don't launch the shell or run the root isolate.

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -50,6 +50,7 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/rasterizer.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_engine.h"
@@ -2304,6 +2305,15 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         kInvalidArguments,
         "Could not infer the Flutter project to run from given arguments.");
   }
+
+  // Begin shorebird
+  if (args->shorebird_args.shorebird_yaml_contents) {
+    settings.application_library_path.push_back(args->shorebird_args.app_path);
+    flutter::ConfigureShorebird(args->shorebird_args, settings);
+  } else {
+    FML_LOG(INFO) << "[shorebird] No shorebird YAML contents provided.";
+  }
+  // End shorebird
 
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2306,6 +2306,10 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         "Could not infer the Flutter project to run from given arguments.");
   }
 
+#if SHOREBIRD_USES_MIXED_MODE
+  flutter::SetBaseSnapshot(settings);
+#endif
+
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(
       std::move(thread_host),               //
@@ -3513,16 +3517,6 @@ FlutterEngineResult FlutterEngineSetNextFrameCallback(
   return kSuccess;
 }
 
-FlutterEngineResult FlutterEngineShorebirdSetBaseSnapshot(
-    FlutterEngineAOTData aot_data) {
-  FML_LOG(ERROR) << "FlutterEngineShorebirdSetBaseSnapshot";
-  Shorebird_SetBaseSnapshots(
-      aot_data->vm_isolate_data, aot_data->vm_isolate_instrs,
-      aot_data->vm_snapshot_data, aot_data->vm_snapshot_instrs);
-  FML_LOG(ERROR) << "FlutterEngineShorebirdSetBaseSnapshot DONE";
-  return kSuccess;
-}
-
 FlutterEngineResult FlutterEngineGetProcAddresses(
     FlutterEngineProcTable* table) {
   if (!table) {
@@ -3577,7 +3571,6 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   SET_PROC(SetNextFrameCallback, FlutterEngineSetNextFrameCallback);
   SET_PROC(AddView, FlutterEngineAddView);
   SET_PROC(RemoveView, FlutterEngineRemoveView);
-  SET_PROC(ShorebirdSetBaseSnapshot, FlutterEngineShorebirdSetBaseSnapshot);
 #undef SET_PROC
 
   return kSuccess;

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2310,12 +2310,12 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   // some platforms (i.e., Windows) need to to swap out the app path before
   // this point.
   // Begin shorebird
-#if FML_OS_MACOSX
-  if (args->shorebird_args.shorebird_yaml_contents) {
-    settings.application_library_path.push_back(args->shorebird_args.app_path);
-    flutter::ConfigureShorebird(args->shorebird_args, settings);
-  }
-#endif
+  // #if FML_OS_MACOSX
+  //   if (args->shorebird_args.shorebird_yaml_contents) {
+  //     settings.application_library_path.push_back(args->shorebird_args.app_path);
+  //     flutter::ConfigureShorebird(args->shorebird_args, settings);
+  //   }
+  // #endif
   // End shorebird
 
   // Create the engine but don't launch the shell or run the root isolate.
@@ -2337,31 +2337,39 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
 
 FlutterEngineResult FlutterEngineRunInitialized(
     FLUTTER_API_SYMBOL(FlutterEngine) engine) {
+  FML_LOG(ERROR) << "In FlutterEngineRunInitialized";
   if (!engine) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine handle was invalid.");
   }
 
   auto embedder_engine = reinterpret_cast<flutter::EmbedderEngine*>(engine);
 
+  FML_LOG(ERROR) << "Checking is valid";
   // The engine must not already be running. Initialize may only be called
   // once on an engine instance.
   if (embedder_engine->IsValid()) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments, "Engine handle was invalid.");
   }
+  FML_LOG(ERROR) << "Checking is valid done";
 
+  FML_LOG(ERROR) << "Launching shell";
   // Step 1: Launch the shell.
   if (!embedder_engine->LaunchShell()) {
     return LOG_EMBEDDER_ERROR(kInvalidArguments,
                               "Could not launch the engine using supplied "
                               "initialization arguments.");
   }
+  FML_LOG(ERROR) << "Launching shell done";
 
+  FML_LOG(ERROR) << "running NotifyCreated";
   // Step 2: Tell the platform view to initialize itself.
   if (!embedder_engine->NotifyCreated()) {
     return LOG_EMBEDDER_ERROR(kInternalInconsistency,
                               "Could not create platform view components.");
   }
+  FML_LOG(ERROR) << "NotifyCreated done";
 
+  FML_LOG(ERROR) << "running root isolate";
   // Step 3: Launch the root isolate.
   if (!embedder_engine->RunRootIsolate()) {
     return LOG_EMBEDDER_ERROR(
@@ -2369,6 +2377,7 @@ FlutterEngineResult FlutterEngineRunInitialized(
         "Could not run the root isolate of the Flutter application using the "
         "project arguments specified.");
   }
+  FML_LOG(ERROR) << "ran root isolate";
 
   return kSuccess;
 }
@@ -3516,6 +3525,16 @@ FlutterEngineResult FlutterEngineSetNextFrameCallback(
   return kSuccess;
 }
 
+FlutterEngineResult FlutterEngineShorebirdSetBaseSnapshot(
+    FlutterEngineAOTData aot_data) {
+  FML_LOG(ERROR) << "FlutterEngineShorebirdSetBaseSnapshot";
+  Shorebird_SetBaseSnapshots(
+      aot_data->vm_isolate_data, aot_data->vm_isolate_instrs,
+      aot_data->vm_snapshot_data, aot_data->vm_snapshot_instrs);
+  FML_LOG(ERROR) << "FlutterEngineShorebirdSetBaseSnapshot DONE";
+  return kSuccess;
+}
+
 FlutterEngineResult FlutterEngineGetProcAddresses(
     FlutterEngineProcTable* table) {
   if (!table) {
@@ -3570,6 +3589,7 @@ FlutterEngineResult FlutterEngineGetProcAddresses(
   SET_PROC(SetNextFrameCallback, FlutterEngineSetNextFrameCallback);
   SET_PROC(AddView, FlutterEngineAddView);
   SET_PROC(RemoveView, FlutterEngineRemoveView);
+  SET_PROC(ShorebirdSetBaseSnapshot, FlutterEngineShorebirdSetBaseSnapshot);
 #undef SET_PROC
 
   return kSuccess;

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2205,6 +2205,42 @@ typedef void (*FlutterLogMessageCallback)(const char* /* tag */,
 typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
 
 typedef struct {
+  /// The version of the app (e.g., 1.0.0).
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_version;
+
+  /// The build number of the app (e.g., 1).
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_build_number;
+
+  /// The text contents of the shorebird.yaml file bundled with the compiled
+  /// app. Note that this is _not_ the same as the shorebird.yaml that exists in
+  /// the user's project.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* shorebird_yaml_contents;
+
+  /// The path to the directory where Shorebird will store patches and state
+  /// data.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* cache_path;
+
+  /// The path to the executable file. This is a Mach-O executable file on
+  /// macOS.
+  ///
+  /// The string can be collected after the call to `FlutterEngineInitialize`
+  /// returns. The string must be NULL terminated.
+  const char* app_path;
+} ShorebirdFlutterProjectArgs;
+
+typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
   /// The path to the Flutter assets directory containing project assets. The
@@ -2503,6 +2539,9 @@ typedef struct {
   /// being registered on the framework side. The callback is invoked from
   /// a task posted to the platform thread.
   FlutterChannelUpdateCallback channel_update_callback;
+
+  /// Data used to initialize Shorebird as part of engine initialization.
+  ShorebirdFlutterProjectArgs shorebird_args;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -3422,6 +3422,8 @@ typedef FlutterEngineResult (*FlutterEngineAddViewFnPtr)(
 typedef FlutterEngineResult (*FlutterEngineRemoveViewFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterRemoveViewInfo* info);
+typedef FlutterEngineResult (*FlutterEngineShorebirdSetBaseSnapshotFnPtr)(
+    FlutterEngineAOTData data);
 
 /// Function-pointer-based versions of the APIs above.
 typedef struct {
@@ -3470,6 +3472,7 @@ typedef struct {
   FlutterEngineSetNextFrameCallbackFnPtr SetNextFrameCallback;
   FlutterEngineAddViewFnPtr AddView;
   FlutterEngineRemoveViewFnPtr RemoveView;
+  FlutterEngineShorebirdSetBaseSnapshotFnPtr ShorebirdSetBaseSnapshot;
 } FlutterEngineProcTable;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -3383,8 +3383,6 @@ typedef FlutterEngineResult (*FlutterEngineAddViewFnPtr)(
 typedef FlutterEngineResult (*FlutterEngineRemoveViewFnPtr)(
     FLUTTER_API_SYMBOL(FlutterEngine) engine,
     const FlutterRemoveViewInfo* info);
-typedef FlutterEngineResult (*FlutterEngineShorebirdSetBaseSnapshotFnPtr)(
-    FlutterEngineAOTData data);
 
 /// Function-pointer-based versions of the APIs above.
 typedef struct {
@@ -3433,7 +3431,6 @@ typedef struct {
   FlutterEngineSetNextFrameCallbackFnPtr SetNextFrameCallback;
   FlutterEngineAddViewFnPtr AddView;
   FlutterEngineRemoveViewFnPtr RemoveView;
-  FlutterEngineShorebirdSetBaseSnapshotFnPtr ShorebirdSetBaseSnapshot;
 } FlutterEngineProcTable;
 
 //------------------------------------------------------------------------------

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2205,42 +2205,6 @@ typedef void (*FlutterLogMessageCallback)(const char* /* tag */,
 typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
 
 typedef struct {
-  /// The version of the app (e.g., 1.0.0).
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_version;
-
-  /// The build number of the app (e.g., 1).
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_build_number;
-
-  /// The text contents of the shorebird.yaml file bundled with the compiled
-  /// app. Note that this is _not_ the same as the shorebird.yaml that exists in
-  /// the user's project.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* shorebird_yaml_contents;
-
-  /// The path to the directory where Shorebird will store patches and state
-  /// data.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* cache_path;
-
-  /// The path to the executable file. This is a Mach-O executable file on
-  /// macOS.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_path;
-} ShorebirdFlutterProjectArgs;
-
-typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
   /// The path to the Flutter assets directory containing project assets. The
@@ -2539,9 +2503,6 @@ typedef struct {
   /// being registered on the framework side. The callback is invoked from
   /// a task posted to the platform thread.
   FlutterChannelUpdateCallback channel_update_callback;
-
-  /// Data used to initialize Shorebird as part of engine initialization.
-  ShorebirdFlutterProjectArgs shorebird_args;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES

--- a/shell/platform/windows/BUILD.gn
+++ b/shell/platform/windows/BUILD.gn
@@ -156,6 +156,7 @@ source_set("flutter_windows_source") {
     ":flutter_windows_headers",
     "//flutter/fml:fml",
     "//flutter/impeller/renderer/backend/gles",
+    "//flutter/shell/common/shorebird:shorebird",
     "//flutter/shell/platform/common:common_cpp",
     "//flutter/shell/platform/common:common_cpp_input",
     "//flutter/shell/platform/common:common_cpp_switches",
@@ -169,6 +170,7 @@ source_set("flutter_windows_source") {
     "//flutter/third_party/angle:libEGL_static",
     "//flutter/third_party/angle:libGLESv2_static",
     "//flutter/third_party/rapidjson",
+    "//flutter/third_party/tonic",
   ]
 }
 

--- a/shell/platform/windows/flutter_project_bundle.h
+++ b/shell/platform/windows/flutter_project_bundle.h
@@ -44,6 +44,10 @@ class FlutterProjectBundle {
   // Sets engine switches.
   void SetSwitches(const std::vector<std::string>& switches);
 
+  void SetAotLibraryPath(const std::filesystem::path& aot_library_path) {
+    aot_library_path_ = aot_library_path;
+  }
+
   // Attempts to load AOT data for this bundle. The returned data must be
   // retained until any engine instance it is passed to has been shut down.
   //

--- a/shell/platform/windows/flutter_windows_engine.cc
+++ b/shell/platform/windows/flutter_windows_engine.cc
@@ -5,15 +5,20 @@
 #include "flutter/shell/platform/windows/flutter_windows_engine.h"
 
 #include <dwmapi.h>
+#include <shlobj.h>
+#include <windows.h>
+#include <winerror.h>
 
 #include <filesystem>
 #include <shared_mutex>
 #include <sstream>
+#include <string>
 
 #include "flutter/fml/logging.h"
 #include "flutter/fml/paths.h"
 #include "flutter/fml/platform/win/wstring_conversion.h"
 #include "flutter/fml/synchronization/waitable_event.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/platform/common/client_wrapper/binary_messenger_impl.h"
 #include "flutter/shell/platform/common/client_wrapper/include/flutter/standard_message_codec.h"
 #include "flutter/shell/platform/common/path_utils.h"
@@ -26,6 +31,7 @@
 #include "flutter/shell/platform/windows/system_utils.h"
 #include "flutter/shell/platform/windows/task_runner.h"
 #include "flutter/third_party/accessibility/ax/ax_node.h"
+#include "third_party/tonic/filesystem/filesystem/file.h"
 
 // winbase.h defines GetCurrentTime as a macro.
 #undef GetCurrentTime
@@ -240,13 +246,125 @@ bool FlutterWindowsEngine::Run() {
   return Run("");
 }
 
+int GetReleaseVersionAndBuildNumber(ReleaseVersion* release_version) {
+  char module_path[MAX_PATH];
+  // Get the full path of the currently running executable. The return value is
+  // the size of the string that was copied to the buffer, with -1 indicating
+  // failure.
+  if (GetModuleFileNameA(NULL, module_path, MAX_PATH) == -1) {
+    return -1;
+  }
+
+  // Get the size of the version information
+  DWORD handle = -1;
+  DWORD version_info_size = GetFileVersionInfoSizeA(module_path, &handle);
+  if (version_info_size == -1) {
+    return -1;
+  }
+
+  // Allocate memory for version info
+  // std::vector<char> version_data(version_info_size);
+  std::unique_ptr<char[]> version_data(new char[version_info_size]);
+  if (!GetFileVersionInfoA(module_path, handle, version_info_size,
+                           version_data.get())) {
+    return -1;
+  }
+
+  // Get the version info structure
+  VS_FIXEDFILEINFO* file_info = nullptr;
+  UINT file_info_size = -1;
+  if (!VerQueryValueA(version_data.get(), "\\",
+                      reinterpret_cast<LPVOID*>(&file_info), &file_info_size)) {
+    return -1;
+  }
+
+  if (file_info) {
+    // Extract version numbers
+    DWORD major = HIWORD(file_info->dwFileVersionMS);
+    DWORD minor = LOWORD(file_info->dwFileVersionMS);
+    DWORD build = HIWORD(file_info->dwFileVersionLS);
+
+    char version[49];
+    snprintf(version, sizeof(version), "%lu.%lu.%lu", major, minor, build);
+    release_version->version = std::string(version);
+    release_version->build_number =
+        std::to_string(LOWORD(file_info->dwFileVersionLS));
+    return kSuccess;
+  }
+
+  return -1;
+}
+
+bool GetLocalAppDataPath(std::string& outPath) {
+  PWSTR path = nullptr;
+  HRESULT result = SHGetKnownFolderPath(FOLDERID_LocalAppData, 0, NULL, &path);
+  if (!SUCCEEDED(result)) {
+    return false;
+  }
+
+  std::wstring widePath(path);
+  std::string localAppDataPath(widePath.begin(), widePath.end());
+  // The calling process is responsible for freeing this resource
+  // https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shgetknownfolderpath
+  CoTaskMemFree(path);
+  outPath = localAppDataPath;
+  return true;
+}
+
+bool SetUpShorebird(std::string assets_path_string, std::string& patch_path) {
+  auto shorebird_yaml_path =
+      fml::paths::JoinPaths({assets_path_string, "shorebird.yaml"});
+  std::string shorebird_yaml_contents("");
+  if (!filesystem::ReadFileToString(shorebird_yaml_path,
+                                    &shorebird_yaml_contents)) {
+    FML_LOG(ERROR) << "Failed to read shorebird.yaml.";
+    return false;
+  }
+
+  std::string code_cache_path;
+  if (!GetLocalAppDataPath(code_cache_path)) {
+    FML_LOG(ERROR) << "Failed to retrieve the local AppData directory.";
+    return false;
+  }
+
+  auto executable_location = fml::paths::GetExecutableDirectoryPath().second;
+  auto app_path =
+      fml::paths::JoinPaths({executable_location, "data", "app.so"});
+  ReleaseVersion release_version;
+  auto release_version_result =
+      GetReleaseVersionAndBuildNumber(&release_version);
+  if (release_version_result != kSuccess) {
+    FML_LOG(ERROR)
+        << "Failed to retrieve the release version and build number.";
+    return false;
+  }
+
+  ShorebirdConfigArgs shorebird_args(code_cache_path, code_cache_path, app_path,
+                                     shorebird_yaml_contents, release_version);
+  return ConfigureShorebird(shorebird_args, patch_path);
+}
+
 bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
+  std::string assets_path_string = project_->assets_path().u8string();
+  std::string icu_path_string = project_->icu_path().u8string();
+
   if (!project_->HasValidPaths()) {
     FML_LOG(ERROR) << "Missing or unresolvable paths to assets.";
     return false;
   }
-  std::string assets_path_string = project_->assets_path().u8string();
-  std::string icu_path_string = project_->icu_path().u8string();
+
+  std::string patch_path;
+  auto setup_shorebird_result = SetUpShorebird(assets_path_string, patch_path);
+  if (setup_shorebird_result) {
+    // If we have a patch installed, we replace the default AOT library path
+    // with the patch path here.
+    FML_LOG(INFO) << "Setting project patch path: " << patch_path;
+    project_->SetAotLibraryPath(patch_path);
+  } else {
+    FML_LOG(ERROR) << "Failed to configure Shorebird.";
+  }
+
+  // This loads AOT data from the project_'s aot_library_path_.
   if (embedder_api_.RunsAOTCompiledDartCode()) {
     aot_data_ = project_->LoadAotData(embedder_api_);
     if (!aot_data_) {
@@ -369,6 +487,15 @@ bool FlutterWindowsEngine::Run(std::string_view entrypoint) {
     if (host->root_isolate_create_callback_) {
       host->root_isolate_create_callback_();
     }
+  };
+  // Copied from shell\platform\darwin\macos\framework\Source\FlutterEngine.mm
+  // Writes log messages to stdout.
+  args.log_message_callback = [](const char* tag, const char* message,
+                                 void* user_data) {
+    if (tag && tag[0]) {
+      std::cout << tag << ": ";
+    }
+    std::cout << message << std::endl;
   };
   args.channel_update_callback = [](const FlutterChannelUpdate* update,
                                     void* user_data) {

--- a/shell/platform/windows/platform_handler.cc
+++ b/shell/platform/windows/platform_handler.cc
@@ -60,7 +60,7 @@ class ScopedGlobalMemory {
     memory_ = ::GlobalAlloc(flags, bytes);
     if (!memory_) {
       FML_LOG(ERROR) << "Unable to allocate global memory: "
-                     << ::GetLastError();
+                     << static_cast<int>(::GetLastError());
     }
   }
 
@@ -68,7 +68,7 @@ class ScopedGlobalMemory {
     if (memory_) {
       if (::GlobalFree(memory_) != nullptr) {
         FML_LOG(ERROR) << "Failed to free global allocation: "
-                       << ::GetLastError();
+                       << static_cast<int>(::GetLastError());
       }
     }
   }
@@ -175,12 +175,12 @@ std::variant<std::wstring, int> ScopedClipboard::GetString() {
 
   HANDLE data = ::GetClipboardData(CF_UNICODETEXT);
   if (data == nullptr) {
-    return ::GetLastError();
+    return static_cast<int>(::GetLastError());
   }
   ScopedGlobalLock locked_data(data);
 
   if (!locked_data.get()) {
-    return ::GetLastError();
+    return static_cast<int>(::GetLastError());
   }
   return static_cast<wchar_t*>(locked_data.get());
 }

--- a/shell/testing/BUILD.gn
+++ b/shell/testing/BUILD.gn
@@ -38,6 +38,7 @@ executable("testing") {
   deps = [
     "$dart_src/runtime:libdart_jit",
     "$dart_src/runtime/bin:dart_io_api",
+    "$dart_src/runtime/bin:elf_loader",
     "//flutter/assets",
     "//flutter/common",
     "//flutter/flow",

--- a/sky/tools/create_full_ios_framework.py
+++ b/sky/tools/create_full_ios_framework.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+#
+# Copyright 2013 The Flutter Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Generates and zip the ios flutter framework including the architecture
+# dependent snapshot.
+
+import argparse
+import os
+import platform
+import shutil
+import subprocess
+import sys
+
+from create_xcframework import create_xcframework  # pylint: disable=import-error
+
+ARCH_SUBPATH = 'mac-arm64' if platform.processor() == 'arm' else 'mac-x64'
+DSYMUTIL = os.path.join(
+    os.path.dirname(__file__), '..', '..', 'buildtools', ARCH_SUBPATH, 'clang', 'bin', 'dsymutil'
+)
+
+buildroot_dir = os.path.abspath(os.path.join(os.path.realpath(__file__), '..', '..', '..', '..'))
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description=(
+          'Creates Flutter.framework, Flutter.xcframework and '
+          'copies architecture-dependent gen_snapshot binaries to output dir'
+      )
+  )
+
+  parser.add_argument('--dst', type=str, required=True)
+  parser.add_argument('--clang-dir', type=str, default='clang_x64')
+  parser.add_argument('--x64-out-dir', type=str)
+  parser.add_argument('--arm64-out-dir', type=str, required=True)
+  parser.add_argument('--simulator-x64-out-dir', type=str, required=True)
+  parser.add_argument('--simulator-arm64-out-dir', type=str, required=False)
+  parser.add_argument('--strip', action='store_true', default=False)
+  parser.add_argument('--dsym', action='store_true', default=False)
+
+  args = parser.parse_args()
+
+  dst = (args.dst if os.path.isabs(args.dst) else os.path.join(buildroot_dir, args.dst))
+
+  arm64_out_dir = (
+      args.arm64_out_dir
+      if os.path.isabs(args.arm64_out_dir) else os.path.join(buildroot_dir, args.arm64_out_dir)
+  )
+
+  x64_out_dir = None
+  if args.x64_out_dir:
+    x64_out_dir = (
+        args.x64_out_dir
+        if os.path.isabs(args.x64_out_dir) else os.path.join(buildroot_dir, args.x64_out_dir)
+    )
+
+  simulator_x64_out_dir = None
+  if args.simulator_x64_out_dir:
+    simulator_x64_out_dir = (
+        args.simulator_x64_out_dir if os.path.isabs(args.simulator_x64_out_dir) else
+        os.path.join(buildroot_dir, args.simulator_x64_out_dir)
+    )
+
+  framework = os.path.join(dst, 'Flutter.framework')
+  simulator_framework = os.path.join(dst, 'sim', 'Flutter.framework')
+  arm64_framework = os.path.join(arm64_out_dir, 'Flutter.framework')
+  simulator_x64_framework = os.path.join(simulator_x64_out_dir, 'Flutter.framework')
+
+  simulator_arm64_out_dir = None
+  if args.simulator_arm64_out_dir:
+    simulator_arm64_out_dir = (
+        args.simulator_arm64_out_dir if os.path.isabs(args.simulator_arm64_out_dir) else
+        os.path.join(buildroot_dir, args.simulator_arm64_out_dir)
+    )
+
+  if args.simulator_arm64_out_dir is not None:
+    simulator_arm64_framework = os.path.join(simulator_arm64_out_dir, 'Flutter.framework')
+
+  if not os.path.isdir(arm64_framework):
+    print('Cannot find iOS arm64 Framework at %s' % arm64_framework)
+    return 1
+
+  if not os.path.isdir(simulator_x64_framework):
+    print('Cannot find iOS x64 simulator Framework at %s' % simulator_framework)
+    return 1
+
+  if not os.path.isfile(DSYMUTIL):
+    print('Cannot find dsymutil at %s' % DSYMUTIL)
+    return 1
+
+  create_framework(
+      args, dst, framework, arm64_framework, simulator_framework, simulator_x64_framework,
+      simulator_arm64_framework
+  )
+
+  extension_safe_dst = os.path.join(dst, 'extension_safe')
+  create_extension_safe_framework(
+      args, extension_safe_dst, '%s_extension_safe' % arm64_out_dir,
+      '%s_extension_safe' % simulator_x64_out_dir, '%s_extension_safe' % simulator_arm64_out_dir
+  )
+
+  generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  generate_analyze_snapshot(args, dst, x64_out_dir, arm64_out_dir)
+  zip_archive(dst)
+  return 0
+
+def create_extension_safe_framework( # pylint: disable=too-many-arguments
+    args, dst, arm64_out_dir, simulator_x64_out_dir, simulator_arm64_out_dir
+):
+  framework = os.path.join(dst, 'Flutter.framework')
+  simulator_framework = os.path.join(dst, 'sim', 'Flutter.framework')
+  arm64_framework = os.path.join(arm64_out_dir, 'Flutter.framework')
+  simulator_x64_framework = os.path.join(simulator_x64_out_dir, 'Flutter.framework')
+  simulator_arm64_framework = os.path.join(simulator_arm64_out_dir, 'Flutter.framework')
+
+  if not os.path.isdir(arm64_framework):
+    print('Cannot find extension safe iOS arm64 Framework at %s' % arm64_framework)
+    return 1
+
+  if not os.path.isdir(simulator_x64_framework):
+    print('Cannot find extension safe iOS x64 simulator Framework at %s' % simulator_x64_framework)
+    return 1
+
+  create_framework(
+      args, dst, framework, arm64_framework, simulator_framework, simulator_x64_framework,
+      simulator_arm64_framework
+  )
+  return 0
+
+def create_framework(  # pylint: disable=too-many-arguments
+    args, dst, framework, arm64_framework, simulator_framework,
+    simulator_x64_framework, simulator_arm64_framework
+):
+  arm64_dylib = os.path.join(arm64_framework, 'Flutter')
+  simulator_x64_dylib = os.path.join(simulator_x64_framework, 'Flutter')
+  simulator_arm64_dylib = os.path.join(simulator_arm64_framework, 'Flutter')
+  if not os.path.isfile(arm64_dylib):
+    print('Cannot find iOS arm64 dylib at %s' % arm64_dylib)
+    return 1
+
+  if not os.path.isfile(simulator_x64_dylib):
+    print('Cannot find iOS simulator dylib at %s' % simulator_x64_dylib)
+    return 1
+
+  # Compute dsym output paths, if enabled.
+  framework_dsym = None
+  simulator_dsym = None
+  if args.dsym:
+    framework_dsym = framework + '.dSYM'
+    simulator_dsym = simulator_framework + '.dSYM'
+
+  # Emit the framework for physical devices.
+  shutil.rmtree(framework, True)
+  shutil.copytree(arm64_framework, framework)
+  framework_binary = os.path.join(framework, 'Flutter')
+  process_framework(args, dst, framework_binary, framework_dsym)
+
+  # Emit the framework for simulators.
+  if args.simulator_arm64_out_dir is not None:
+    shutil.rmtree(simulator_framework, True)
+    shutil.copytree(simulator_arm64_framework, simulator_framework)
+
+    simulator_framework_binary = os.path.join(simulator_framework, 'Flutter')
+
+    # Create the arm64/x64 simulator fat framework.
+    subprocess.check_call([
+        'lipo', simulator_x64_dylib, simulator_arm64_dylib, '-create', '-output',
+        simulator_framework_binary
+    ])
+    process_framework(args, dst, simulator_framework_binary, simulator_dsym)
+  else:
+    simulator_framework = simulator_x64_framework
+
+  # Create XCFramework from the arm-only fat framework and the arm64/x64
+  # simulator frameworks, or just the x64 simulator framework if only that one
+  # exists.
+  xcframeworks = [simulator_framework, framework]
+  dsyms = [simulator_dsym, framework_dsym] if args.dsym else None
+  create_xcframework(location=dst, name='Flutter', frameworks=xcframeworks, dsyms=dsyms)
+
+  # Add the x64 simulator into the fat framework.
+  subprocess.check_call([
+      'lipo', arm64_dylib, simulator_x64_dylib, '-create', '-output', framework_binary
+  ])
+
+  process_framework(args, dst, framework_binary, framework_dsym)
+  return 0
+
+
+def embed_codesign_configuration(config_path, contents):
+  with open(config_path, 'w') as file:
+    file.write('\n'.join(contents) + '\n')
+
+
+def zip_archive(dst):
+  ios_file_with_entitlements = ['gen_snapshot_arm64']
+  ios_file_without_entitlements = [
+      'Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',  # pylint: disable=line-too-long
+      'extension_safe/Flutter.xcframework/ios-arm64/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter',  # pylint: disable=line-too-long
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/Flutter.framework/Flutter',
+      'extension_safe/Flutter.xcframework/ios-arm64_x86_64-simulator/dSYMs/Flutter.framework.dSYM/Contents/Resources/DWARF/Flutter'  # pylint: disable=line-too-long
+  ]
+  embed_codesign_configuration(os.path.join(dst, 'entitlements.txt'), ios_file_with_entitlements)
+
+  embed_codesign_configuration(
+      os.path.join(dst, 'without_entitlements.txt'), ios_file_without_entitlements
+  )
+
+  subprocess.check_call([
+      'zip',
+      '-r',
+      'artifacts.zip',
+      'analyze_snapshot_arm64',
+      'gen_snapshot_arm64',
+      'Flutter.xcframework',
+      'entitlements.txt',
+      'without_entitlements.txt',
+      'extension_safe/Flutter.xcframework',
+  ],
+                        cwd=dst)
+
+  # Generate Flutter.dSYM.zip for manual symbolification.
+  #
+  # Historically, the framework dSYM was named Flutter.dSYM, so in order to
+  # remain backward-compatible with existing instructions in docs/Crashes.md
+  # and existing tooling such as dart-lang/dart_ci, we rename back to that name
+  #
+  # TODO(cbracken): remove these archives and the upload steps once we bundle
+  # dSYMs in app archives. https://github.com/flutter/flutter/issues/116493
+  framework_dsym = os.path.join(dst, 'Flutter.framework.dSYM')
+  if os.path.exists(framework_dsym):
+    renamed_dsym = framework_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(framework_dsym, renamed_dsym)
+    subprocess.check_call(['zip', '-r', 'Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
+
+  extension_safe_dsym = os.path.join(dst, 'extension_safe', 'Flutter.framework.dSYM')
+  if os.path.exists(extension_safe_dsym):
+    renamed_dsym = extension_safe_dsym.replace('Flutter.framework.dSYM', 'Flutter.dSYM')
+    os.rename(extension_safe_dsym, renamed_dsym)
+    subprocess.check_call(['zip', '-r', 'extension_safe_Flutter.dSYM.zip', 'Flutter.dSYM'], cwd=dst)
+
+
+def process_framework(args, dst, framework_binary, dsym):
+  if dsym:
+    subprocess.check_call([DSYMUTIL, '-o', dsym, framework_binary])
+
+  if args.strip:
+    # copy unstripped
+    unstripped_out = os.path.join(dst, 'Flutter.unstripped')
+    shutil.copyfile(framework_binary, unstripped_out)
+    subprocess.check_call(['strip', '-x', '-S', framework_binary])
+
+
+def generate_gen_snapshot(args, dst, x64_out_dir, arm64_out_dir):
+  if x64_out_dir:
+    _generate_gen_snapshot(x64_out_dir, os.path.join(dst, 'gen_snapshot_x64'))
+
+  if arm64_out_dir:
+    _generate_gen_snapshot(
+        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'gen_snapshot_arm64')
+    )
+
+
+def _generate_gen_snapshot(directory, destination):
+  gen_snapshot_dir = os.path.join(directory, 'gen_snapshot')
+  if not os.path.isfile(gen_snapshot_dir):
+    print('Cannot find gen_snapshot at %s' % gen_snapshot_dir)
+    sys.exit(1)
+
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', gen_snapshot_dir, '-o', destination])
+
+
+def generate_analyze_snapshot(args, dst, x64_out_dir, arm64_out_dir):
+  if x64_out_dir:
+    _generate_analyze_snapshot(x64_out_dir, os.path.join(dst, 'analyze_snapshot_x64'))
+
+  if arm64_out_dir:
+    _generate_analyze_snapshot(
+        os.path.join(arm64_out_dir, args.clang_dir), os.path.join(dst, 'analyze_snapshot_arm64')
+    )
+
+
+def _generate_analyze_snapshot(directory, destination):
+  analyze_snapshot_dir = os.path.join(directory, 'analyze_snapshot')
+  if not os.path.isfile(analyze_snapshot_dir):
+    print('Cannot find analyze_snapshot at %s' % analyze_snapshot_dir)
+    sys.exit(1)
+
+  subprocess.check_call(['xcrun', 'bitcode_strip', '-r', analyze_snapshot_dir, '-o', destination])
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/testing/run_tests.py
+++ b/testing/run_tests.py
@@ -444,6 +444,7 @@ def run_cc_tests(build_dir, executable_filter, coverage, capture_core_dump):
         make_test('platform_view_android_delegate_unittests'),
         # https://github.com/flutter/flutter/issues/36295
         make_test('shell_unittests'),
+        make_test('shorebird_unittests'),
     ]
 
   if is_windows():


### PR DESCRIPTION
# WIP

This crashes on launch, trying to figure out why

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               mac_local_eng [16201]
Path:                  /Users/USER/*/macos_1.0.0+6_615309.app/Contents/MacOS/mac_local_eng
Identifier:            com.example.macLocalEng
Version:               1.0.0 (6)
Code Type:             ARM-64 (Native)
Parent Process:        launchd [1]
User ID:               501

Date/Time:             2025-01-09 13:53:37.1822 -0500
OS Version:            macOS 15.1.1 (24B91)
Report Version:        12
Anonymous UUID:        BB22797C-0019-473B-0833-F82E2A6C7A38

Sleep/Wake UUID:       B18498B9-9E69-4651-B7BE-6646AC42BDEE

Time Awake Since Boot: 11000 seconds
Time Since Wake:       3129 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_BAD_ACCESS (SIGSEGV)
Exception Codes:       KERN_INVALID_ADDRESS at 0x0000000000000017
Exception Codes:       0x0000000000000001, 0x0000000000000017

Termination Reason:    Namespace SIGNAL, Code 11 Segmentation fault: 11
Terminating Process:   exc handler [16201]

VM Region Info: 0x17 is not in any region.  Bytes before following region: 4341809129
      REGION TYPE                    START - END         [ VSIZE] PRT/MAX SHRMOD  REGION DETAIL
      UNUSED SPACE AT START
--->  
      __TEXT                      102cac000-102cb0000    [   16K] r-x/r-x SM=COW  /Users/USER/*/macos_1.0.0+6_615309.app/Contents/MacOS/mac_local_eng

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   FlutterMacOS                  	       0x1055087e0 flutter::SearchMapping(std::_fl::function<std::_fl::unique_ptr<fml::Mapping, std::_fl::default_delete<fml::Mapping>> ()> const&, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>> const&, std::_fl::vector<std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>, std::_fl::allocator<std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>>> const&, char const*, bool) + 76
1   FlutterMacOS                  	       0x105508614 flutter::DartSnapshot::VMSnapshotFromSettings(flutter::Settings const&) + 76
2   FlutterMacOS                  	       0x10565fa9c FlutterEngineRunInitialized + 828
3   FlutterMacOS                  	       0x104c747d0 -[FlutterEngine runWithEntrypoint:] + 7660
4   FlutterMacOS                  	       0x104c9951c -[FlutterViewController viewWillAppear] + 108
5   AppKit                        	       0x1841f09c8 -[NSViewController _sendViewWillAppear] + 32
6   AppKit                        	       0x1841f0890 -[NSViewController _windowWillOrderOnScreen] + 80
7   AppKit                        	       0x184bb1578 -[NSView _windowWillOrderOnScreen] + 56
8   AppKit                        	       0x184bb15e4 -[NSView _windowWillOrderOnScreen] + 164
9   AppKit                        	       0x1841f0744 -[NSWindow _doWindowWillBeVisibleAsSheet:] + 40
10  AppKit                        	       0x184bc7534 -[NSWindow _reallyDoOrderWindowAboveOrBelow:] + 1040
11  AppKit                        	       0x184bc810c -[NSWindow _reallyDoOrderWindow:] + 64
12  AppKit                        	       0x184bc836c -[NSWindow _doOrderWindow:] + 264
13  AppKit                        	       0x1840d9acc -[NSIBObjectData nibInstantiateWithOwner:options:topLevelObjects:] + 1192
14  AppKit                        	       0x1840cf204 loadNib + 340
15  AppKit                        	       0x1840ce82c +[NSBundle(NSNibLoading) _loadNibFile:nameTable:options:withZone:ownerBundle:] + 560
16  AppKit                        	       0x1840ce530 -[NSBundle(NSNibLoading) loadNibNamed:owner:topLevelObjects:] + 180
17  AppKit                        	       0x1840ce354 +[NSBundle(NSNibLoading) loadNibNamed:owner:] + 300
18  AppKit                        	       0x1840c11dc NSApplicationMain + 496
19  mac_local_eng                 	       0x102caea08 specialized static NSApplicationDelegate.main() + 24 [inlined]
20  mac_local_eng                 	       0x102caea08 static AppDelegate.$main() + 24 (/<compiler-generated>:4) [inlined]
21  mac_local_eng                 	       0x102caea08 main + 36
22  dyld                          	       0x180164274 start + 2840

Thread 1:
0   libsystem_pthread.dylib       	       0x1804e20e8 start_wqthread + 0

Thread 2:
0   libsystem_pthread.dylib       	       0x1804e20e8 start_wqthread + 0

Thread 3:
0   libsystem_pthread.dylib       	       0x1804e20e8 start_wqthread + 0

Thread 4:
0   libsystem_kernel.dylib        	       0x1804a5db0 semaphore_wait_trap + 8
1   libdispatch.dylib             	       0x180334bf4 _dispatch_sema4_wait + 28
2   libdispatch.dylib             	       0x1803352a8 _dispatch_semaphore_wait_slow + 132
3   FlutterMacOS                  	       0x104bf807c std::thread::park::h82ab23e2edfe40a2 + 200
4   FlutterMacOS                  	       0x104989480 reqwest::blocking::client::ClientBuilder::build::h0c0bcc9145f1f2b0 + 1132
5   FlutterMacOS                  	       0x10498a3a0 reqwest::blocking::client::Client::new::ha96048650328ab6e + 52
6   FlutterMacOS                  	       0x104896f8c updater::network::patch_check_request_default::h6293862823ae2c16 + 236
7   FlutterMacOS                  	       0x1048bdf64 updater::updater::update_internal::h066312c2a7688d44 + 1220
8   FlutterMacOS                  	       0x1048ab758 updater::updater_lock::with_updater_thread_lock::h9db9dc68717e2060 + 160
9   FlutterMacOS                  	       0x1048b6ee0 std::sys_common::backtrace::__rust_begin_short_backtrace::h93f8f9672e350564 + 32
10  FlutterMacOS                  	       0x1048b8880 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h28ceef3d45525ef3 + 140
11  FlutterMacOS                  	       0x104c1b3b8 std::sys::pal::unix::thread::Thread::new::thread_start::h50a0ef5291b272f3 + 52
12  libsystem_pthread.dylib       	       0x1804e72e4 _pthread_start + 136
13  libsystem_pthread.dylib       	       0x1804e20fc thread_start + 8

Thread 5:: io.flutter.ui
0   libsystem_kernel.dylib        	       0x1804a5e34 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x1804b85d0 mach_msg2_internal + 80
2   libsystem_kernel.dylib        	       0x1804ae9d8 mach_msg_overwrite + 480
3   libsystem_kernel.dylib        	       0x1804a617c mach_msg + 24
4   CoreFoundation                	       0x1805cdedc __CFRunLoopServiceMachPort + 160
5   CoreFoundation                	       0x1805cc73c __CFRunLoopRun + 1212
6   CoreFoundation                	       0x1805cbbc4 CFRunLoopRunSpecific + 588
7   FlutterMacOS                  	       0x104cdb9f8 fml::MessageLoopDarwin::Run() + 188
8   FlutterMacOS                  	       0x104cdb008 std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()() + 324
9   FlutterMacOS                  	       0x104cda964 fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*) + 56
10  libsystem_pthread.dylib       	       0x1804e72e4 _pthread_start + 136
11  libsystem_pthread.dylib       	       0x1804e20fc thread_start + 8

Thread 6:: io.flutter.raster
0   libsystem_kernel.dylib        	       0x1804a5e34 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x1804b85d0 mach_msg2_internal + 80
2   libsystem_kernel.dylib        	       0x1804ae9d8 mach_msg_overwrite + 480
3   libsystem_kernel.dylib        	       0x1804a617c mach_msg + 24
4   CoreFoundation                	       0x1805cdedc __CFRunLoopServiceMachPort + 160
5   CoreFoundation                	       0x1805cc73c __CFRunLoopRun + 1212
6   CoreFoundation                	       0x1805cbbc4 CFRunLoopRunSpecific + 588
7   FlutterMacOS                  	       0x104cdb9f8 fml::MessageLoopDarwin::Run() + 188
8   FlutterMacOS                  	       0x104cdb008 std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()() + 324
9   FlutterMacOS                  	       0x104cda964 fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*) + 56
10  libsystem_pthread.dylib       	       0x1804e72e4 _pthread_start + 136
11  libsystem_pthread.dylib       	       0x1804e20fc thread_start + 8

Thread 7:: io.flutter.io
0   libsystem_kernel.dylib        	       0x1804a5e34 mach_msg2_trap + 8
1   libsystem_kernel.dylib        	       0x1804b85d0 mach_msg2_internal + 80
2   libsystem_kernel.dylib        	       0x1804ae9d8 mach_msg_overwrite + 480
3   libsystem_kernel.dylib        	       0x1804a617c mach_msg + 24
4   CoreFoundation                	       0x1805cdedc __CFRunLoopServiceMachPort + 160
5   CoreFoundation                	       0x1805cc73c __CFRunLoopRun + 1212
6   CoreFoundation                	       0x1805cbbc4 CFRunLoopRunSpecific + 588
7   FlutterMacOS                  	       0x104cdb9f8 fml::MessageLoopDarwin::Run() + 188
8   FlutterMacOS                  	       0x104cdb008 std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()() + 324
9   FlutterMacOS                  	       0x104cda964 fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*) + 56
10  libsystem_pthread.dylib       	       0x1804e72e4 _pthread_start + 136
11  libsystem_pthread.dylib       	       0x1804e20fc thread_start + 8

Thread 8:: reqwest-internal-sync-runtime
0   FlutterMacOS                  	       0x104958918 _$LT$core..iter..adapters..cloned..Cloned$LT$I$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$::fold::h7ab5820d4f5f6d1d + 0
1   FlutterMacOS                  	       0x104935f4c reqwest::async_impl::client::ClientBuilder::build::hbd391827de0cb7e4 + 3196
2   FlutterMacOS                  	       0x104952358 reqwest::blocking::client::ClientHandle::new::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h2a162d0bce565833 (.llvm.8769366987040919665) + 96
3   FlutterMacOS                  	       0x104987980 tokio::runtime::scheduler::current_thread::Context::enter::h85f033478f20dab1 + 232
4   FlutterMacOS                  	       0x10494fe88 tokio::runtime::context::scoped::Scoped$LT$T$GT$::set::h14c9a7c1e3fa445e + 112
5   FlutterMacOS                  	       0x104987cfc tokio::runtime::scheduler::current_thread::CoreGuard::block_on::h4e51f79326dd4b4a + 188
6   FlutterMacOS                  	       0x10495023c tokio::runtime::context::runtime::enter_runtime::hfb74bbbb2d313d1a + 700
7   FlutterMacOS                  	       0x10496705c tokio::runtime::runtime::Runtime::block_on::h460b68cfecd4f9cb + 96
8   FlutterMacOS                  	       0x10496d250 std::sys_common::backtrace::__rust_begin_short_backtrace::hd3def15bc9996a0f + 328
9   FlutterMacOS                  	       0x104983518 core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h683168126f35a86d + 200
10  FlutterMacOS                  	       0x104c1b3b8 std::sys::pal::unix::thread::Thread::new::thread_start::h50a0ef5291b272f3 + 52
11  libsystem_pthread.dylib       	       0x1804e72e4 _pthread_start + 136
12  libsystem_pthread.dylib       	       0x1804e20fc thread_start + 8


Thread 0 crashed with ARM Thread State (64-bit):
    x0: 0x000000016d14bfc0   x1: 0x0000000000000000   x2: 0x000000016d14c048   x3: 0x000000016d14c160
    x4: 0x000000010593d01d   x5: 0x0000000000000000   x6: 0x0000000000001940   x7: 0xffffffff00043400
    x8: 0x0000000000000000   x9: 0x0000000000000000  x10: 0x0000000000000000  x11: 0x0000000105ae7b28
   x12: 0x0000000000000000  x13: 0x0000000000000000  x14: 0x00000000001ff800  x15: 0x00000000000007fb
   x16: 0x00000001804e21e4  x17: 0x00000001804e1b34  x18: 0x0000000000000000  x19: 0x000000016d14bfc0
   x20: 0x000000010593d01d  x21: 0x000000016d14c160  x22: 0x000000016d14c048  x23: 0x0000000000000000
   x24: 0x0000000000000000  x25: 0x000000016d14e2c0  x26: 0x0000000105ae7bb8  x27: 0x0000000105ae2000
   x28: 0x000000016d14e308   fp: 0x000000016d14bfa0   lr: 0x0000000105508614
    sp: 0x000000016d14bde0   pc: 0x00000001055087e0 cpsr: 0x60001000
   far: 0x0000000000000017  esr: 0x92000006 (Data Abort) byte read Translation fault

Binary Images:
       0x102cac000 -        0x102caffff com.example.macLocalEng (1.0.0) <c4289727-269f-3eb4-8dab-d271e604c93a> /Users/USER/*/macos_1.0.0+6_615309.app/Contents/MacOS/mac_local_eng
       0x104888000 -        0x105a2bfff io.flutter.flutter-macos (1.0) <4c4c44ff-5555-3144-a1de-cbb1a256c713> /Users/USER/*/macos_1.0.0+6_615309.app/Contents/Frameworks/FlutterMacOS.framework/Versions/A/FlutterMacOS
       0x1045cc000 -        0x1045d7fff libobjc-trampolines.dylib (*) <f1242604-dcb7-30a9-a19a-182991e6e645> /usr/lib/libobjc-trampolines.dylib
       0x112378000 -        0x1126dbfff io.flutter.flutter.app (1.0) <a9f6d6a9-e545-3bb2-a2c0-43523a14e7a2> /Users/USER/*/macos_1.0.0+6_615309.app/Contents/Frameworks/App.framework/Versions/A/App
       0x1126f0000 -        0x112e13fff com.apple.AGXMetalG14X (322.10) <f6817cf9-b70f-382a-839f-1fdd973b9138> /System/Library/Extensions/AGXMetalG14X.bundle/Contents/MacOS/AGXMetalG14X
       0x1840bd000 -        0x1854b8fff com.apple.AppKit (6.9) <49d8b1b6-0ea8-36ad-89fd-a41acf00a742> /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit
       0x18015e000 -        0x1801e07b3 dyld (*) <6beafde4-b011-3e47-8aae-4d7b6e4bb7e8> /usr/lib/dyld
               0x0 - 0xffffffffffffffff ??? (*) <00000000-0000-0000-0000-000000000000> ???
       0x1804e0000 -        0x1804ecfff libsystem_pthread.dylib (*) <3b8268be-4e02-3b4a-8b41-baed2bbaacff> /usr/lib/system/libsystem_pthread.dylib
       0x1804a5000 -        0x1804dfff7 libsystem_kernel.dylib (*) <9fea25a4-e8ca-3f3d-901c-a53ff2bc7217> /usr/lib/system/libsystem_kernel.dylib
       0x180330000 -        0x180376fff libdispatch.dylib (*) <9ea577db-73c2-39d8-9fc0-544fa595a142> /usr/lib/system/libdispatch.dylib
       0x180550000 -        0x180a44fff com.apple.CoreFoundation (6.9) <ae4610f8-7c5c-3484-858e-cae7457d206e> /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation

External Modification Summary:
  Calls made by other processes targeting this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by this process:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0
  Calls made by all processes on this machine:
    task_for_pid: 0
    thread_create: 0
    thread_set_state: 0

VM Region Summary:
ReadOnly portion of Libraries: Total=902.6M resident=0K(0%) swapped_out_or_unallocated=902.6M(100%)
Writable regions: Total=1.5G written=691K(0%) resident=691K(0%) swapped_out=0K(0%) unallocated=1.5G(100%)

                                VIRTUAL   REGION 
REGION TYPE                        SIZE    COUNT (non-coalesced) 
===========                     =======  ======= 
Activity Tracing                   256K        1 
ColorSync                          144K        5 
CoreGraphics                        16K        1 
Foundation                          16K        1 
Kernel Alloc Once                   32K        1 
MALLOC                             1.5G       59 
MALLOC guard page                  288K       18 
STACK GUARD                       56.1M        9 
Stack                             19.7M        9 
VM_ALLOCATE                         48K        3 
__AUTH                            1150K      213 
__AUTH_CONST                      18.9M      367 
__DATA                            4720K      350 
__DATA_CONST                      13.7M      371 
__DATA_DIRTY                       696K      112 
__FONT_DATA                        2352        1 
__LINKEDIT                       595.5M        6 
__OBJC_RW                         2354K        1 
__TEXT                           307.1M      389 
__TPRO_CONST                       272K        2 
mapped file                      207.5M       21 
owned unmapped memory               32K        1 
page table in kernel               691K        1 
shared memory                     1376K       13 
===========                     =======  ======= 
TOTAL                              2.7G     1955 



-----------
Full Report
-----------

{"app_name":"mac_local_eng","timestamp":"2025-01-09 13:53:38.00 -0500","app_version":"1.0.0","slice_uuid":"c4289727-269f-3eb4-8dab-d271e604c93a","build_version":"6","platform":1,"bundleID":"com.example.macLocalEng","share_with_app_devs":0,"is_first_party":0,"bug_type":"309","os_version":"macOS 15.1.1 (24B91)","roots_installed":0,"name":"mac_local_eng","incident_id":"41D42B46-0358-4EFD-9BC4-37551F9B1D5C"}
{
  "uptime" : 11000,
  "procRole" : "Foreground",
  "version" : 2,
  "userID" : 501,
  "deployVersion" : 210,
  "modelCode" : "Mac14,14",
  "coalitionID" : 5205,
  "osVersion" : {
    "train" : "macOS 15.1.1",
    "build" : "24B91",
    "releaseType" : "User"
  },
  "captureTime" : "2025-01-09 13:53:37.1822 -0500",
  "codeSigningMonitor" : 1,
  "incident" : "41D42B46-0358-4EFD-9BC4-37551F9B1D5C",
  "pid" : 16201,
  "translated" : false,
  "cpuType" : "ARM-64",
  "roots_installed" : 0,
  "bug_type" : "309",
  "procLaunch" : "2025-01-09 13:53:36.6534 -0500",
  "procStartAbsTime" : 266054905148,
  "procExitAbsTime" : 266067564556,
  "procName" : "mac_local_eng",
  "procPath" : "\/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/MacOS\/mac_local_eng",
  "bundleInfo" : {"CFBundleShortVersionString":"1.0.0","CFBundleVersion":"6","CFBundleIdentifier":"com.example.macLocalEng"},
  "storeInfo" : {"deviceIdentifierForVendor":"1F5BBF5F-C50A-5691-A40A-CA4DB7745FB1","thirdParty":true},
  "parentProc" : "launchd",
  "parentPid" : 1,
  "coalitionName" : "com.example.macLocalEng",
  "crashReporterKey" : "BB22797C-0019-473B-0833-F82E2A6C7A38",
  "codeSigningID" : "com.example.macLocalEng",
  "codeSigningTeamID" : "",
  "codeSigningFlags" : 570425861,
  "codeSigningValidationCategory" : 10,
  "codeSigningTrustLevel" : 4294967295,
  "instructionByteStream" : {"beforePC":"9AMEqvUDA6r2AwKq+AMBqvMDAKooKQCQCAlA+QgBQPmoAxr4aABA+Q==","atPC":"CV3AOckA+DcAAcA9CAlA+egbAPngC4A9FAAAFBltQKl\/WwDxiAAAVA=="},
  "bootSessionUUID" : "EE50F3E7-45C0-42CB-9BB0-112D8D556687",
  "wakeTime" : 3129,
  "sleepWakeUUID" : "B18498B9-9E69-4651-B7BE-6646AC42BDEE",
  "sip" : "enabled",
  "vmRegionInfo" : "0x17 is not in any region.  Bytes before following region: 4341809129\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      UNUSED SPACE AT START\n--->  \n      __TEXT                      102cac000-102cb0000    [   16K] r-x\/r-x SM=COW  \/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/MacOS\/mac_local_eng",
  "exception" : {"codes":"0x0000000000000001, 0x0000000000000017","rawCodes":[1,23],"type":"EXC_BAD_ACCESS","signal":"SIGSEGV","subtype":"KERN_INVALID_ADDRESS at 0x0000000000000017"},
  "termination" : {"flags":0,"code":11,"namespace":"SIGNAL","indicator":"Segmentation fault: 11","byProc":"exc handler","byPid":16201},
  "vmregioninfo" : "0x17 is not in any region.  Bytes before following region: 4341809129\n      REGION TYPE                    START - END         [ VSIZE] PRT\/MAX SHRMOD  REGION DETAIL\n      UNUSED SPACE AT START\n--->  \n      __TEXT                      102cac000-102cb0000    [   16K] r-x\/r-x SM=COW  \/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/MacOS\/mac_local_eng",
  "extMods" : {"caller":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"system":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"targeted":{"thread_create":0,"thread_set_state":0,"task_for_pid":0},"warnings":0},
  "faultingThread" : 0,
  "threads" : [{"triggered":true,"id":873069,"threadState":{"x":[{"value":6125043648},{"value":0},{"value":6125043784},{"value":6125044064},{"value":4388540445,"symbolLocation":34060,"symbol":"flutter::kFontChange"},{"value":0},{"value":6464},{"value":18446744069414859776},{"value":0},{"value":0},{"value":0},{"value":4390288168,"symbolLocation":0,"symbol":"flutter::PersistentCache::cache_sksl_ (.0)"},{"value":0},{"value":0},{"value":2095104},{"value":2043},{"value":6447571428,"symbolLocation":0,"symbol":"pthread_cond_broadcast"},{"value":6447569716,"symbolLocation":156,"symbol":"_pthread_mutex_check_init_slow"},{"value":0},{"value":6125043648},{"value":4388540445,"symbolLocation":34060,"symbol":"flutter::kFontChange"},{"value":6125044064},{"value":6125043784},{"value":0},{"value":0},{"value":6125052608},{"value":4390288312,"symbolLocation":0,"symbol":"flutter::(anonymous namespace)::PerformInitializationTasks(flutter::Settings&)::gShellSettingsInitialization"},{"value":4390264832,"symbolLocation":192,"symbol":"std::_fl::init_months()::months"},{"value":6125052680}],"flavor":"ARM_THREAD_STATE64","lr":{"value":4384130580},"cpsr":{"value":1610616832},"fp":{"value":6125043616},"sp":{"value":6125043168},"esr":{"value":2449473542,"description":"(Data Abort) byte read Translation fault"},"pc":{"value":4384131040,"matchesCrashFrame":1},"far":{"value":23}},"queue":"com.apple.main-thread","frames":[{"imageOffset":13109216,"symbol":"flutter::SearchMapping(std::_fl::function<std::_fl::unique_ptr<fml::Mapping, std::_fl::default_delete<fml::Mapping>> ()> const&, std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>> const&, std::_fl::vector<std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>, std::_fl::allocator<std::_fl::basic_string<char, std::_fl::char_traits<char>, std::_fl::allocator<char>>>> const&, char const*, bool)","symbolLocation":76,"imageIndex":1},{"imageOffset":13108756,"symbol":"flutter::DartSnapshot::VMSnapshotFromSettings(flutter::Settings const&)","symbolLocation":76,"imageIndex":1},{"imageOffset":14514844,"symbol":"FlutterEngineRunInitialized","symbolLocation":828,"imageIndex":1},{"imageOffset":4114384,"symbol":"-[FlutterEngine runWithEntrypoint:]","symbolLocation":7660,"imageIndex":1},{"imageOffset":4265244,"symbol":"-[FlutterViewController viewWillAppear]","symbolLocation":108,"imageIndex":1},{"imageOffset":1259976,"symbol":"-[NSViewController _sendViewWillAppear]","symbolLocation":32,"imageIndex":5},{"imageOffset":1259664,"symbol":"-[NSViewController _windowWillOrderOnScreen]","symbolLocation":80,"imageIndex":5},{"imageOffset":11486584,"symbol":"-[NSView _windowWillOrderOnScreen]","symbolLocation":56,"imageIndex":5},{"imageOffset":11486692,"symbol":"-[NSView _windowWillOrderOnScreen]","symbolLocation":164,"imageIndex":5},{"imageOffset":1259332,"symbol":"-[NSWindow _doWindowWillBeVisibleAsSheet:]","symbolLocation":40,"imageIndex":5},{"imageOffset":11576628,"symbol":"-[NSWindow _reallyDoOrderWindowAboveOrBelow:]","symbolLocation":1040,"imageIndex":5},{"imageOffset":11579660,"symbol":"-[NSWindow _reallyDoOrderWindow:]","symbolLocation":64,"imageIndex":5},{"imageOffset":11580268,"symbol":"-[NSWindow _doOrderWindow:]","symbolLocation":264,"imageIndex":5},{"imageOffset":117452,"symbol":"-[NSIBObjectData nibInstantiateWithOwner:options:topLevelObjects:]","symbolLocation":1192,"imageIndex":5},{"imageOffset":74244,"symbol":"loadNib","symbolLocation":340,"imageIndex":5},{"imageOffset":71724,"symbol":"+[NSBundle(NSNibLoading) _loadNibFile:nameTable:options:withZone:ownerBundle:]","symbolLocation":560,"imageIndex":5},{"imageOffset":70960,"symbol":"-[NSBundle(NSNibLoading) loadNibNamed:owner:topLevelObjects:]","symbolLocation":180,"imageIndex":5},{"imageOffset":70484,"symbol":"+[NSBundle(NSNibLoading) loadNibNamed:owner:]","symbolLocation":300,"imageIndex":5},{"imageOffset":16860,"symbol":"NSApplicationMain","symbolLocation":496,"imageIndex":5},{"imageOffset":10760,"sourceFile":"AppDelegate.swift","symbol":"specialized static NSApplicationDelegate.main()","imageIndex":0,"symbolLocation":24,"inline":true},{"symbol":"static AppDelegate.$main()","inline":true,"imageIndex":0,"imageOffset":10760,"symbolLocation":24,"sourceLine":4,"sourceFile":"\/<compiler-generated>"},{"imageOffset":10760,"sourceFile":"AppDelegate.swift","symbol":"main","symbolLocation":36,"imageIndex":0},{"imageOffset":25204,"symbol":"start","symbolLocation":2840,"imageIndex":6}]},{"id":873074,"frames":[{"imageOffset":8424,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":8}],"threadState":{"x":[{"value":6125629440},{"value":4355},{"value":6125092864},{"value":0},{"value":409602},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6125629440},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447571176},"far":{"value":0}}},{"id":873075,"frames":[{"imageOffset":8424,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":8}],"threadState":{"x":[{"value":6126202880},{"value":10499},{"value":6125666304},{"value":0},{"value":409602},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6126202880},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447571176},"far":{"value":0}}},{"id":873076,"frames":[{"imageOffset":8424,"symbol":"start_wqthread","symbolLocation":0,"imageIndex":8}],"threadState":{"x":[{"value":6126776320},{"value":8707},{"value":6126239744},{"value":0},{"value":409604},{"value":18446744073709551615},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0},{"value":0}],"flavor":"ARM_THREAD_STATE64","lr":{"value":0},"cpsr":{"value":4096},"fp":{"value":0},"sp":{"value":6126776320},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447571176},"far":{"value":0}}},{"id":873116,"frames":[{"imageOffset":3504,"symbol":"semaphore_wait_trap","symbolLocation":8,"imageIndex":9},{"imageOffset":19444,"symbol":"_dispatch_sema4_wait","symbolLocation":28,"imageIndex":10},{"imageOffset":21160,"symbol":"_dispatch_semaphore_wait_slow","symbolLocation":132,"imageIndex":10},{"imageOffset":3604604,"symbol":"std::thread::park::h82ab23e2edfe40a2","symbolLocation":200,"imageIndex":1},{"imageOffset":1053824,"symbol":"reqwest::blocking::client::ClientBuilder::build::h0c0bcc9145f1f2b0","symbolLocation":1132,"imageIndex":1},{"imageOffset":1057696,"symbol":"reqwest::blocking::client::Client::new::ha96048650328ab6e","symbolLocation":52,"imageIndex":1},{"imageOffset":61324,"symbol":"updater::network::patch_check_request_default::h6293862823ae2c16","symbolLocation":236,"imageIndex":1},{"imageOffset":221028,"symbol":"updater::updater::update_internal::h066312c2a7688d44","symbolLocation":1220,"imageIndex":1},{"imageOffset":145240,"symbol":"updater::updater_lock::with_updater_thread_lock::h9db9dc68717e2060","symbolLocation":160,"imageIndex":1},{"imageOffset":192224,"symbol":"std::sys_common::backtrace::__rust_begin_short_backtrace::h93f8f9672e350564","symbolLocation":32,"imageIndex":1},{"imageOffset":198784,"symbol":"core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h28ceef3d45525ef3","symbolLocation":140,"imageIndex":1},{"imageOffset":3748792,"symbol":"std::sys::pal::unix::thread::Thread::new::thread_start::h50a0ef5291b272f3","symbolLocation":52,"imageIndex":1},{"imageOffset":29412,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":8},{"imageOffset":8444,"symbol":"thread_start","symbolLocation":8,"imageIndex":8}],"threadState":{"x":[{"value":14},{"value":8589934595},{"value":171798697235},{"value":170437187207683},{"value":14680198217728},{"value":170437187207168},{"value":48},{"value":0},{"value":0},{"value":1},{"value":105553133518848},{"value":4384},{"value":32},{"value":1},{"value":4294966921},{"value":2043},{"value":18446744073709551580},{"value":8279924792},{"value":0},{"value":105553170211328},{"value":105553170211264},{"value":18446744073709551615},{"value":4390259744,"symbolLocation":0,"symbol":"log::MAX_LOG_LEVEL_FILTER::hbbf7378b85f37acc"},{"value":6128918328},{"value":4372064064,"symbolLocation":0,"symbol":"_$LT$std..thread..ThreadId$u20$as$u20$core..fmt..Debug$GT$::fmt::h1e6125055f7d27a4"},{"value":4389581744,"symbolLocation":648,"symbol":"anon.4fb298b54ba363b7142c2eab9be2def2.50.llvm.12354361120700063374"},{"value":1},{"value":2},{"value":18446744073709551615}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6445812724},"cpsr":{"value":1610616832},"fp":{"value":6128914880},"sp":{"value":6128914864},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447324592},"far":{"value":0}}},{"id":873117,"name":"io.flutter.ui","threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592},{"value":180332791857152},{"value":0},{"value":180332791857152},{"value":2},{"value":4294967295},{"value":18446744073709550527},{"value":2},{"value":0},{"value":0},{"value":0},{"value":41987},{"value":2095104},{"value":2043},{"value":18446744073709551569},{"value":37},{"value":0},{"value":4294967295},{"value":2},{"value":180332791857152},{"value":0},{"value":180332791857152},{"value":6131064520},{"value":8589934592},{"value":21592279046},{"value":21592279046},{"value":4412409862}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6447400400},"cpsr":{"value":4096},"fp":{"value":6131064368},"sp":{"value":6131064288},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447324724},"far":{"value":0}},"frames":[{"imageOffset":3636,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":9},{"imageOffset":79312,"symbol":"mach_msg2_internal","symbolLocation":80,"imageIndex":9},{"imageOffset":39384,"symbol":"mach_msg_overwrite","symbolLocation":480,"imageIndex":9},{"imageOffset":4476,"symbol":"mach_msg","symbolLocation":24,"imageIndex":9},{"imageOffset":515804,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":11},{"imageOffset":509756,"symbol":"__CFRunLoopRun","symbolLocation":1212,"imageIndex":11},{"imageOffset":506820,"symbol":"CFRunLoopRunSpecific","symbolLocation":588,"imageIndex":11},{"imageOffset":4536824,"symbol":"fml::MessageLoopDarwin::Run()","symbolLocation":188,"imageIndex":1},{"imageOffset":4534280,"symbol":"std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()()","symbolLocation":324,"imageIndex":1},{"imageOffset":4532580,"symbol":"fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*)","symbolLocation":56,"imageIndex":1},{"imageOffset":29412,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":8},{"imageOffset":8444,"symbol":"thread_start","symbolLocation":8,"imageIndex":8}]},{"id":873118,"name":"io.flutter.raster","threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592},{"value":152845001162752},{"value":0},{"value":152845001162752},{"value":2},{"value":4294967295},{"value":18446744073709550527},{"value":2},{"value":0},{"value":0},{"value":0},{"value":35587},{"value":2095104},{"value":2043},{"value":18446744073709551569},{"value":18},{"value":0},{"value":4294967295},{"value":2},{"value":152845001162752},{"value":0},{"value":152845001162752},{"value":6133210824},{"value":8589934592},{"value":21592279046},{"value":21592279046},{"value":4412409862}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6447400400},"cpsr":{"value":4096},"fp":{"value":6133210672},"sp":{"value":6133210592},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447324724},"far":{"value":0}},"frames":[{"imageOffset":3636,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":9},{"imageOffset":79312,"symbol":"mach_msg2_internal","symbolLocation":80,"imageIndex":9},{"imageOffset":39384,"symbol":"mach_msg_overwrite","symbolLocation":480,"imageIndex":9},{"imageOffset":4476,"symbol":"mach_msg","symbolLocation":24,"imageIndex":9},{"imageOffset":515804,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":11},{"imageOffset":509756,"symbol":"__CFRunLoopRun","symbolLocation":1212,"imageIndex":11},{"imageOffset":506820,"symbol":"CFRunLoopRunSpecific","symbolLocation":588,"imageIndex":11},{"imageOffset":4536824,"symbol":"fml::MessageLoopDarwin::Run()","symbolLocation":188,"imageIndex":1},{"imageOffset":4534280,"symbol":"std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()()","symbolLocation":324,"imageIndex":1},{"imageOffset":4532580,"symbol":"fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*)","symbolLocation":56,"imageIndex":1},{"imageOffset":29412,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":8},{"imageOffset":8444,"symbol":"thread_start","symbolLocation":8,"imageIndex":8}]},{"id":873119,"name":"io.flutter.io","threadState":{"x":[{"value":268451845},{"value":21592279046},{"value":8589934592},{"value":160541582557184},{"value":0},{"value":160541582557184},{"value":2},{"value":4294967295},{"value":18446744073709550527},{"value":2},{"value":0},{"value":0},{"value":0},{"value":37379},{"value":4294967176},{"value":2043},{"value":18446744073709551569},{"value":8},{"value":0},{"value":4294967295},{"value":2},{"value":160541582557184},{"value":0},{"value":160541582557184},{"value":6135357128},{"value":8589934592},{"value":21592279046},{"value":21592279046},{"value":4412409862}],"flavor":"ARM_THREAD_STATE64","lr":{"value":6447400400},"cpsr":{"value":4096},"fp":{"value":6135356976},"sp":{"value":6135356896},"esr":{"value":1442840704,"description":" Address size fault"},"pc":{"value":6447324724},"far":{"value":0}},"frames":[{"imageOffset":3636,"symbol":"mach_msg2_trap","symbolLocation":8,"imageIndex":9},{"imageOffset":79312,"symbol":"mach_msg2_internal","symbolLocation":80,"imageIndex":9},{"imageOffset":39384,"symbol":"mach_msg_overwrite","symbolLocation":480,"imageIndex":9},{"imageOffset":4476,"symbol":"mach_msg","symbolLocation":24,"imageIndex":9},{"imageOffset":515804,"symbol":"__CFRunLoopServiceMachPort","symbolLocation":160,"imageIndex":11},{"imageOffset":509756,"symbol":"__CFRunLoopRun","symbolLocation":1212,"imageIndex":11},{"imageOffset":506820,"symbol":"CFRunLoopRunSpecific","symbolLocation":588,"imageIndex":11},{"imageOffset":4536824,"symbol":"fml::MessageLoopDarwin::Run()","symbolLocation":188,"imageIndex":1},{"imageOffset":4534280,"symbol":"std::_fl::__function::__func<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0, std::_fl::allocator<fml::Thread::Thread(std::_fl::function<void (fml::Thread::ThreadConfig const&)> const&, fml::Thread::ThreadConfig const&)::$_0>, void ()>::operator()()","symbolLocation":324,"imageIndex":1},{"imageOffset":4532580,"symbol":"fml::ThreadHandle::ThreadHandle(std::_fl::function<void ()>&&)::$_0::__invoke(void*)","symbolLocation":56,"imageIndex":1},{"imageOffset":29412,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":8},{"imageOffset":8444,"symbol":"thread_start","symbolLocation":8,"imageIndex":8}]},{"id":873120,"name":"reqwest-internal-sync-runtime","threadState":{"x":[{"value":4389553736,"symbolLocation":216,"symbol":"anon.9900e2be5db1de027c4dbadb082a32a4.55.llvm.5723513636364506096"},{"value":4389564392,"symbolLocation":10872,"symbol":"anon.9900e2be5db1de027c4dbadb082a32a4.55.llvm.5723513636364506096"},{"value":6137499008},{"value":23},{"value":5},{"value":4146196538},{"value":105553151140768},{"value":0},{"value":10656},{"value":5746996224},{"value":799744},{"value":6266496},{"value":774},{"value":4294934551},{"value":1518},{"value":4294934015},{"value":2205830223},{"value":57},{"value":0},{"value":0},{"value":4389553672,"symbolLocation":152,"symbol":"anon.9900e2be5db1de027c4dbadb082a32a4.55.llvm.5723513636364506096"},{"value":8},{"value":8},{"value":0},{"value":0},{"value":4390258897,"symbolLocation":0,"symbol":"__rust_no_alloc_shim_is_unstable"},{"value":1},{"value":6137496960},{"value":1000000000}],"flavor":"ARM_THREAD_STATE64","lr":{"value":4371734348},"cpsr":{"value":1073745920},"fp":{"value":6137499504},"sp":{"value":6137496912},"esr":{"value":2181038087,"description":"(Instruction Abort) Translation fault"},"pc":{"value":4371876120},"far":{"value":4371876120}},"frames":[{"imageOffset":854296,"symbol":"_$LT$core..iter..adapters..cloned..Cloned$LT$I$GT$$u20$as$u20$core..iter..traits..iterator..Iterator$GT$::fold::h7ab5820d4f5f6d1d","symbolLocation":0,"imageIndex":1},{"imageOffset":712524,"symbol":"reqwest::async_impl::client::ClientBuilder::build::hbd391827de0cb7e4","symbolLocation":3196,"imageIndex":1},{"imageOffset":828248,"symbol":"reqwest::blocking::client::ClientHandle::new::_$u7b$$u7b$closure$u7d$$u7d$::_$u7b$$u7b$closure$u7d$$u7d$::h2a162d0bce565833 (.llvm.8769366987040919665)","symbolLocation":96,"imageIndex":1},{"imageOffset":1046912,"symbol":"tokio::runtime::scheduler::current_thread::Context::enter::h85f033478f20dab1","symbolLocation":232,"imageIndex":1},{"imageOffset":818824,"symbol":"tokio::runtime::context::scoped::Scoped$LT$T$GT$::set::h14c9a7c1e3fa445e","symbolLocation":112,"imageIndex":1},{"imageOffset":1047804,"symbol":"tokio::runtime::scheduler::current_thread::CoreGuard::block_on::h4e51f79326dd4b4a","symbolLocation":188,"imageIndex":1},{"imageOffset":819772,"symbol":"tokio::runtime::context::runtime::enter_runtime::hfb74bbbb2d313d1a","symbolLocation":700,"imageIndex":1},{"imageOffset":913500,"symbol":"tokio::runtime::runtime::Runtime::block_on::h460b68cfecd4f9cb","symbolLocation":96,"imageIndex":1},{"imageOffset":938576,"symbol":"std::sys_common::backtrace::__rust_begin_short_backtrace::hd3def15bc9996a0f","symbolLocation":328,"imageIndex":1},{"imageOffset":1029400,"symbol":"core::ops::function::FnOnce::call_once$u7b$$u7b$vtable.shim$u7d$$u7d$::h683168126f35a86d","symbolLocation":200,"imageIndex":1},{"imageOffset":3748792,"symbol":"std::sys::pal::unix::thread::Thread::new::thread_start::h50a0ef5291b272f3","symbolLocation":52,"imageIndex":1},{"imageOffset":29412,"symbol":"_pthread_start","symbolLocation":136,"imageIndex":8},{"imageOffset":8444,"symbol":"thread_start","symbolLocation":8,"imageIndex":8}]}],
  "usedImages" : [
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4341809152,
    "CFBundleShortVersionString" : "1.0.0",
    "CFBundleIdentifier" : "com.example.macLocalEng",
    "size" : 16384,
    "uuid" : "c4289727-269f-3eb4-8dab-d271e604c93a",
    "path" : "\/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/MacOS\/mac_local_eng",
    "name" : "mac_local_eng",
    "CFBundleVersion" : "6"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4371021824,
    "CFBundleShortVersionString" : "1.0",
    "CFBundleIdentifier" : "io.flutter.flutter-macos",
    "size" : 18497536,
    "uuid" : "4c4c44ff-5555-3144-a1de-cbb1a256c713",
    "path" : "\/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/Frameworks\/FlutterMacOS.framework\/Versions\/A\/FlutterMacOS",
    "name" : "FlutterMacOS",
    "CFBundleVersion" : "1.0"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4368154624,
    "size" : 49152,
    "uuid" : "f1242604-dcb7-30a9-a19a-182991e6e645",
    "path" : "\/usr\/lib\/libobjc-trampolines.dylib",
    "name" : "libobjc-trampolines.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64",
    "base" : 4600594432,
    "CFBundleShortVersionString" : "1.0",
    "CFBundleIdentifier" : "io.flutter.flutter.app",
    "size" : 3555328,
    "uuid" : "a9f6d6a9-e545-3bb2-a2c0-43523a14e7a2",
    "path" : "\/Users\/USER\/*\/macos_1.0.0+6_615309.app\/Contents\/Frameworks\/App.framework\/Versions\/A\/App",
    "name" : "App",
    "CFBundleVersion" : "1.0"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 4604231680,
    "CFBundleShortVersionString" : "322.10",
    "CFBundleIdentifier" : "com.apple.AGXMetalG14X",
    "size" : 7487488,
    "uuid" : "f6817cf9-b70f-382a-839f-1fdd973b9138",
    "path" : "\/System\/Library\/Extensions\/AGXMetalG14X.bundle\/Contents\/MacOS\/AGXMetalG14X",
    "name" : "AGXMetalG14X",
    "CFBundleVersion" : "322.10"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6510333952,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.AppKit",
    "size" : 20955136,
    "uuid" : "49d8b1b6-0ea8-36ad-89fd-a41acf00a742",
    "path" : "\/System\/Library\/Frameworks\/AppKit.framework\/Versions\/C\/AppKit",
    "name" : "AppKit",
    "CFBundleVersion" : "2575.20.21"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6443884544,
    "size" : 534452,
    "uuid" : "6beafde4-b011-3e47-8aae-4d7b6e4bb7e8",
    "path" : "\/usr\/lib\/dyld",
    "name" : "dyld"
  },
  {
    "size" : 0,
    "source" : "A",
    "base" : 0,
    "uuid" : "00000000-0000-0000-0000-000000000000"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6447562752,
    "size" : 53248,
    "uuid" : "3b8268be-4e02-3b4a-8b41-baed2bbaacff",
    "path" : "\/usr\/lib\/system\/libsystem_pthread.dylib",
    "name" : "libsystem_pthread.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6447321088,
    "size" : 241656,
    "uuid" : "9fea25a4-e8ca-3f3d-901c-a53ff2bc7217",
    "path" : "\/usr\/lib\/system\/libsystem_kernel.dylib",
    "name" : "libsystem_kernel.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6445793280,
    "size" : 290816,
    "uuid" : "9ea577db-73c2-39d8-9fc0-544fa595a142",
    "path" : "\/usr\/lib\/system\/libdispatch.dylib",
    "name" : "libdispatch.dylib"
  },
  {
    "source" : "P",
    "arch" : "arm64e",
    "base" : 6448021504,
    "CFBundleShortVersionString" : "6.9",
    "CFBundleIdentifier" : "com.apple.CoreFoundation",
    "size" : 5197824,
    "uuid" : "ae4610f8-7c5c-3484-858e-cae7457d206e",
    "path" : "\/System\/Library\/Frameworks\/CoreFoundation.framework\/Versions\/A\/CoreFoundation",
    "name" : "CoreFoundation",
    "CFBundleVersion" : "3107"
  }
],
  "sharedCache" : {
  "base" : 6443073536,
  "size" : 4753735680,
  "uuid" : "f66bac4e-1e78-38af-b867-c1cf5daa0302"
},
  "vmSummary" : "ReadOnly portion of Libraries: Total=902.6M resident=0K(0%) swapped_out_or_unallocated=902.6M(100%)\nWritable regions: Total=1.5G written=691K(0%) resident=691K(0%) swapped_out=0K(0%) unallocated=1.5G(100%)\n\n                                VIRTUAL   REGION \nREGION TYPE                        SIZE    COUNT (non-coalesced) \n===========                     =======  ======= \nActivity Tracing                   256K        1 \nColorSync                          144K        5 \nCoreGraphics                        16K        1 \nFoundation                          16K        1 \nKernel Alloc Once                   32K        1 \nMALLOC                             1.5G       59 \nMALLOC guard page                  288K       18 \nSTACK GUARD                       56.1M        9 \nStack                             19.7M        9 \nVM_ALLOCATE                         48K        3 \n__AUTH                            1150K      213 \n__AUTH_CONST                      18.9M      367 \n__DATA                            4720K      350 \n__DATA_CONST                      13.7M      371 \n__DATA_DIRTY                       696K      112 \n__FONT_DATA                        2352        1 \n__LINKEDIT                       595.5M        6 \n__OBJC_RW                         2354K        1 \n__TEXT                           307.1M      389 \n__TPRO_CONST                       272K        2 \nmapped file                      207.5M       21 \nowned unmapped memory               32K        1 \npage table in kernel               691K        1 \nshared memory                     1376K       13 \n===========                     =======  ======= \nTOTAL                              2.7G     1955 \n",
  "legacyInfo" : {
  "threadTriggered" : {
    "queue" : "com.apple.main-thread"
  }
},
  "logWritingSignature" : "9a450b48b3ef84d34db90154cacbbc7b042e567a",
  "trialInfo" : {
  "rollouts" : [
    {
      "rolloutId" : "63f9578e238e7b23a1f3030a",
      "factorPackIds" : {

      },
      "deploymentId" : 240000005
    },
    {
      "rolloutId" : "642da32dea3b2418c750f848",
      "factorPackIds" : {
        "VISUAL_INTELLIGENCE_VICTORIA" : "66d8b2f77cd4b62688efd2cf"
      },
      "deploymentId" : 240000004
    }
  ],
  "experiments" : [

  ]
}
}

Model: Mac14,14, BootROM 11881.41.5, proc 24:16:8 processors, 64 GB, SMC 
Graphics: Apple M2 Ultra, Apple M2 Ultra, Built-In
Display: Gigabyte M32U, 3840 x 2160 (2160p/4K UHD 1 - Ultra High Definition), Main, MirrorOff, Online
Memory Module: LPDDR5, Micron
AirPort: spairport_wireless_card_type_wifi (0x14E4, 0x4388), wl0: Sep 23 2024 18:39:43 version 23.900.1.1.41.51.169 FWID 01-b725314d
IO80211_driverkit-1315.7 "IO80211_driverkit-1315.7" Sep 28 2024 16:04:40
Bluetooth: Version (null), 0 services, 0 devices, 0 incoming serial ports
Network Service: Ethernet, Ethernet, en0
USB Device: USB31Bus
USB Device: USB31Bus
USB Device: USB31Bus
USB Device: USB31Bus
USB Device: USB31Bus
USB Device: Brio 501
USB Device: USB31Bus
USB Device: USB2.1 Hub
USB Device: USB Receiver
USB Device: Keychron K3
USB Device: HID Device
USB Device: USB31Bus
Thunderbolt Bus: Mac Studio, Apple Inc.
Thunderbolt Bus: Mac Studio, Apple Inc.
Thunderbolt Bus: Mac Studio, Apple Inc.
Thunderbolt Bus: Mac Studio, Apple Inc.
Thunderbolt Bus: Mac Studio, Apple Inc.
Thunderbolt Bus: Mac Studio, Apple Inc.
```