### PR TITLE
feat: use windows method for loading patches on intel macs

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -18,7 +18,7 @@ vars = {
   "dart_sdk_revision": "5c6f8122c1ee85f833ea3b69b3b85dc07303e8d2",
   "dart_sdk_git": "git@github.com:shorebirdtech/dart-sdk.git",
   "updater_git": "https://github.com/shorebirdtech/updater.git",
-  "updater_rev": "71b5ed65fab03fcf241edf0c74d027de9998da51",
+  "updater_rev": "ba52a62b5d1b064cce363ef98c6165b1e2f78059",
 
   # WARNING: DO NOT EDIT canvaskit_cipd_instance MANUALLY
   # See `lib/web_ui/README.md` for how to roll CanvasKit to a new version.

--- a/common/config.gni
+++ b/common/config.gni
@@ -77,6 +77,14 @@ if (is_ios || is_mac || is_android || is_win) {
   feature_defines_list += [ "SHOREBIRD_PLATFORM_SUPPORTED=1" ]
 }
 
+if (is_ios) {
+  feature_defines_list += [ "SHOREBIRD_USE_LINKER=1" ]
+}
+
+if (is_mac && (target_cpu == "arm" || target_cpu == "arm64")) {
+  feature_defines_list += [ "SHOREBIRD_USE_LINKER=1" ]
+}
+
 if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",

--- a/common/config.gni
+++ b/common/config.gni
@@ -78,7 +78,7 @@ if (is_ios || is_mac || is_android || is_win) {
 }
 
 if (is_ios) {
-  feature_defines_list += [ "SHOREBIRD_USE_LINKER=1" ]
+  feature_defines_list += [ "SHOREBIRD_USE_INTERPRETER=1" ]
 }
 
 if (is_ios || is_mac) {

--- a/common/config.gni
+++ b/common/config.gni
@@ -81,10 +81,6 @@ if (is_ios) {
   feature_defines_list += [ "SHOREBIRD_USE_LINKER=1" ]
 }
 
-if (is_mac && (target_cpu == "arm" || target_cpu == "arm64")) {
-  feature_defines_list += [ "SHOREBIRD_USE_LINKER=1" ]
-}
-
 if (is_ios || is_mac) {
   flutter_cflags_objc = [
     "-Werror=overriding-method-mismatch",

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -57,7 +57,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
-#if SHOREBIRD_USE_LINKER
+#if SHOREBIRD_USE_INTERPRETER
   // Detect when we're trying to load a Shorebird patch.
   auto patch_path = native_library_path.front();
   bool is_patch = patch_path.find(".vmcode") != std::string::npos;
@@ -141,7 +141,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
       }
     }
 
-#if SHOREBIRD_USE_LINKER
+#if SHOREBIRD_USE_INTERPRETER
   }  // !is_patch
 #endif
 

--- a/runtime/dart_snapshot.cc
+++ b/runtime/dart_snapshot.cc
@@ -57,7 +57,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
     const std::vector<std::string>& native_library_path,
     const char* native_library_symbol_name,
     bool is_executable) {
-#if FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_USE_LINKER
   // Detect when we're trying to load a Shorebird patch.
   auto patch_path = native_library_path.front();
   bool is_patch = patch_path.find(".vmcode") != std::string::npos;
@@ -141,7 +141,7 @@ static std::shared_ptr<const fml::Mapping> SearchMapping(
       }
     }
 
-#if FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_USE_LINKER
   }  // !is_patch
 #endif
 

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -83,7 +83,7 @@ FileCallbacks ShorebirdFileCallbacks() {
 // FIXME: consolidate this with the other ConfigureShorebird
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path) {
-  patch_path = args.release_app_library_path;
+  patch_path = "";  // args.release_app_library_path;
   auto shorebird_updater_dir_name = "shorebird_updater";
 
   auto code_cache_dir = fml::paths::JoinPaths(
@@ -239,7 +239,7 @@ void ConfigureShorebird(std::string code_cache_path,
   // https://github.com/shorebirdtech/shorebird/issues/950
 
   // We only set the base snapshot on iOS for now.
-#if FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_USE_LINKER
   SetBaseSnapshot(settings);
 #endif
 
@@ -249,7 +249,7 @@ void ConfigureShorebird(std::string code_cache_path,
     shorebird_free_string(c_active_path);
     FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
 
-#if FML_OS_IOS || FML_OS_MACOSX
+#if SHOREBIRD_USE_LINKER
     // On iOS we add the patch to the front of the list instead of clearing
     // the list, to allow dart_shapshot.cc to still find the base snapshot
     // for the vm isolate.

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -223,7 +223,7 @@ void ConfigureShorebird(std::string code_cache_path,
   // https://github.com/shorebirdtech/shorebird/issues/950
 
   // We only set the base snapshot on iOS for now.
-#if SHOREBIRD_USE_LINKER
+#if SHOREBIRD_USE_INTERPRETER
   SetBaseSnapshot(settings);
 #endif
 
@@ -233,7 +233,7 @@ void ConfigureShorebird(std::string code_cache_path,
     shorebird_free_string(c_active_path);
     FML_LOG(INFO) << "Shorebird updater: active path: " << active_path;
 
-#if SHOREBIRD_USE_LINKER
+#if SHOREBIRD_USE_INTERPRETER
     // On iOS we add the patch to the front of the list instead of clearing
     // the list, to allow dart_shapshot.cc to still find the base snapshot
     // for the vm isolate.

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -83,7 +83,7 @@ FileCallbacks ShorebirdFileCallbacks() {
 // FIXME: consolidate this with the other ConfigureShorebird
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path) {
-  patch_path = "";  // args.release_app_library_path;
+  patch_path = args.release_app_library_path;
   auto shorebird_updater_dir_name = "shorebird_updater";
 
   auto code_cache_dir = fml::paths::JoinPaths(
@@ -125,12 +125,6 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   // instead we will provide examples of how to build a custom update UI
   // within Dart, including updating as part of login, etc.
   // https://github.com/shorebirdtech/shorebird/issues/950
-
-  // We only set the base snapshot on iOS for now.
-  // TODO: this won't compile as we don't have a settings object here.
-  // #if FML_OS_IOS || FML_OS_MACOSX
-  //   SetBaseSnapshot(settings);
-  // #endif
 
   FML_LOG(INFO) << "Checking for active patch";
   char* c_active_path = shorebird_next_boot_patch_path();

--- a/shell/common/shorebird/shorebird.cc
+++ b/shell/common/shorebird/shorebird.cc
@@ -172,16 +172,6 @@ bool ConfigureShorebird(const ShorebirdConfigArgs& args,
   return true;
 }
 
-void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        Settings& settings) {
-  // cache_path is used for both code_cache and app_storage, as we don't persist
-  // any data between releases. args.app_path is appended to
-  // the settings.application_library_path vector at this function's call site.
-  ConfigureShorebird(args.cache_path, args.cache_path, settings,
-                     args.shorebird_yaml_contents, args.app_version,
-                     args.app_build_number);
-}
-
 void ConfigureShorebird(std::string code_cache_path,
                         std::string app_storage_path,
                         Settings& settings,

--- a/shell/common/shorebird/shorebird.h
+++ b/shell/common/shorebird/shorebird.h
@@ -33,9 +33,6 @@ struct ShorebirdConfigArgs {
 bool ConfigureShorebird(const ShorebirdConfigArgs& args,
                         std::string& patch_path);
 
-void ConfigureShorebird(const ShorebirdFlutterProjectArgs& args,
-                        Settings& settings);
-
 void ConfigureShorebird(std::string code_cache_path,
                         std::string app_storage_path,
                         Settings& settings,

--- a/shell/platform/darwin/macos/BUILD.gn
+++ b/shell/platform/darwin/macos/BUILD.gn
@@ -123,6 +123,7 @@ source_set("flutter_framework_source") {
     ":macos_gpu_configuration",
     "//flutter/flow:flow",
     "//flutter/fml",
+    "//flutter/shell/common/shorebird",
     "//flutter/shell/platform/common:common_cpp_accessibility",
     "//flutter/shell/platform/common:common_cpp_enums",
     "//flutter/shell/platform/common:common_cpp_input",

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -11,6 +11,7 @@
 
 #include "flutter/common/constants.h"
 #include "flutter/fml/paths.h"
+#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/platform/common/app_lifecycle_state.h"
 #include "flutter/shell/platform/common/engine_switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
@@ -585,6 +586,48 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
+- (BOOL)setUpNonLinkerShorebird:(NSString**) patchPath {
+  NSLog(@"[shorebird] setting up non-linker shorebird");
+  NSString* bundlePath =
+      [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
+                                   URLByAppendingPathComponent:@"App.framework"]] bundlePath];
+  bundlePath = [bundlePath stringByAppendingString:@"/App"];
+  // flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
+  NSString* assetsPath = _project.assetsPath;
+  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
+                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
+  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
+                                                             encoding:NSUTF8StringEncoding
+                                                                error:nil];
+  NSString* appVersion =
+      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
+  NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
+  // flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
+  // flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
+
+  std::string cache_path =
+      fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
+  // flutterArguments.shorebird_args.cache_path = cache_path.c_str();
+  // flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
+
+  flutter::ReleaseVersion release_version = {appVersion.UTF8String, appBuildNumber.UTF8String};
+  flutter::ShorebirdConfigArgs shorebird_args(
+    cache_path, cache_path, bundlePath.UTF8String,
+    shorebirdYamlContents.UTF8String, release_version);
+  NSLog(@"[shorebird] calling ConfigureShorebird");
+  std::string patch_path;
+  auto res = flutter::ConfigureShorebird(shorebird_args, patch_path);
+  if (!res) {
+    NSLog(@"[shorebird] ConfigureShorebird failed");
+    return NO;
+  }
+
+  NSLog(@"[shorebird] ConfigureShorebird success!");
+  *patchPath = [NSString stringWithUTF8String:patch_path.c_str()];
+  NSLog(@"[shorebird] patchPath: %@", *patchPath);
+  return YES;
+}
+
 - (BOOL)runWithEntrypoint:(NSString*)entrypoint {
   if (self.running) {
     return NO;
@@ -663,22 +706,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       .thread_priority_setter = SetThreadPriority};
   flutterArguments.custom_task_runners = &custom_task_runners;
 
-  [self loadAOTData:_project.assetsPath];
-  if (_aotData) {
-    flutterArguments.aot_data = _aotData;
-  }
-
-  flutterArguments.compositor = [self createFlutterCompositor];
-
-  flutterArguments.on_pre_engine_restart_callback = [](void* user_data) {
-    FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
-    [engine engineCallbackOnPreEngineRestart];
-  };
-
-  flutterArguments.vsync_callback = [](void* user_data, intptr_t baton) {
-    FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
-    [engine onVSync:baton];
-  };
 
   NSString* bundlePath =
       [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
@@ -701,6 +728,40 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
   flutterArguments.shorebird_args.cache_path = cache_path.c_str();
   flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
+
+  #if SHOREBIRD_USE_LINKER
+    NSLog(@"[shorebird] Using Shorebird linker");
+    FML_LOG(INFO) << "[shorebird][fml] Using shorebird linker";
+    [self loadAOTData:_project.assetsPath];
+  #else
+    NSLog(@"[shorebird] Not using shorebird linker");
+    FML_LOG(INFO) << "[shorebird][fml] Not using shorebird linker";
+    NSString* patchPath;
+    auto configureShorebirdRes = [self setUpNonLinkerShorebird:&patchPath];
+    if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
+      NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
+      [self loadAOTDataFromPatch:patchPath];
+    } else {
+      NSLog(@"[shorebird] failed to configure shorebird");
+      [self loadAOTData:_project.assetsPath];
+    }
+  #endif
+
+  if (_aotData) {
+    flutterArguments.aot_data = _aotData;
+  }
+
+  flutterArguments.compositor = [self createFlutterCompositor];
+
+  flutterArguments.on_pre_engine_restart_callback = [](void* user_data) {
+    FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
+    [engine engineCallbackOnPreEngineRestart];
+  };
+
+  flutterArguments.vsync_callback = [](void* user_data, intptr_t baton) {
+    FlutterEngine* engine = (__bridge FlutterEngine*)user_data;
+    [engine onVSync:baton];
+  };
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
   FlutterEngineResult result = _embedderAPI.Initialize(
@@ -733,6 +794,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 }
 
 - (void)loadAOTData:(NSString*)assetsDir {
+  NSLog(@"[shorebird] loading AOT data from assetsDir: %@", assetsDir);
+  FML_LOG(INFO) << "[shorebird][fml] Loading AOT data from assetsDir: " << assetsDir.UTF8String;
   if (!_embedderAPI.RunsAOTCompiledDartCode()) {
     return;
   }
@@ -743,8 +806,10 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   // This is the location where the test fixture places the snapshot file.
   // For applications built by Flutter tool, this is in "App.framework".
   NSString* elfPath = [NSString pathWithComponents:@[ assetsDir, @"app_elf_snapshot.so" ]];
+  FML_LOG(INFO) << "elf path is " << elfPath.UTF8String;
 
   if (![fileManager fileExistsAtPath:elfPath isDirectory:&isDirOut]) {
+    FML_LOG(INFO) << "[shorebird][fml] elfPath does not exist: " << elfPath.UTF8String;
     return;
   }
 
@@ -755,6 +820,34 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   auto result = _embedderAPI.CreateAOTData(&source, &_aotData);
   if (result != kSuccess) {
     NSLog(@"Failed to load AOT data from: %@", elfPath);
+  }
+}
+
+- (void)loadAOTDataFromPatch:(NSString *)patchPath {
+  NSLog(@"[shorebird] loading AOT data from patchPath: %@", patchPath);
+  FML_LOG(INFO) << "[shorebird][fml] Loading AOT data from patchPath: " << patchPath.UTF8String;
+  BOOL isDirOut = false;  // required for NSFileManager fileExistsAtPath.
+  NSFileManager* fileManager = [NSFileManager defaultManager];
+
+  if (![fileManager fileExistsAtPath:patchPath isDirectory:&isDirOut]) {
+    NSLog(@"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
+    return;
+  }
+
+  FlutterEngineAOTDataSource source = {};
+  source.type = kFlutterEngineAOTDataSourceTypeElfPath;
+  source.elf_path = [patchPath cStringUsingEncoding:NSUTF8StringEncoding];
+
+  NSLog(@"!!!");
+  NSLog(@"!!!");
+  NSLog(@"Creating AOT data from patchPath: %@", patchPath);
+  NSLog(@"!!!");
+  NSLog(@"!!!");
+  auto result = _embedderAPI.CreateAOTData(&source, &_aotData);
+  if (result != kSuccess) {
+    NSLog(@"Failed to load AOT data from: %@", patchPath);
+  } else {
+    NSLog(@"[shorebird] created AOT data");
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -698,6 +698,19 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       .thread_priority_setter = SetThreadPriority};
   flutterArguments.custom_task_runners = &custom_task_runners;
 
+  NSString* elfPath;
+  BOOL configureShorebirdRes = [self configureShorebird:&elfPath];
+  if (!configureShorebirdRes) {
+    // No patch exists, or we failed to configure shorebird. This is a fallback.
+    // Upstream, this code lives in -(void)loadAOTData:.
+    //
+    // This is the location where the test fixture places the snapshot file.
+    // For applications built by Flutter tool, this is in "App.framework".
+    elfPath = [NSString pathWithComponents:@[ _project.assetsPath, @"app_elf_snapshot.so" ]];
+  }
+
+  [self loadAOTData:elfPath];
+
   if (_aotData) {
     flutterArguments.aot_data = _aotData;
   }
@@ -715,16 +728,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   };
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
-
-  NSString* patchPath;
-  auto configureShorebirdRes = [self configureShorebird:&patchPath];
-  if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
-    NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
-    [self loadAOTDataFromPatch:patchPath];
-  } else {
-    NSLog(@"[shorebird] failed to configure shorebird");
-    [self loadAOTData:_project.assetsPath];
-  }
 
   FlutterEngineResult result = _embedderAPI.Initialize(
       FLUTTER_ENGINE_VERSION, &rendererConfig, &flutterArguments, (__bridge void*)(self), &_engine);
@@ -755,9 +758,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   return YES;
 }
 
-- (void)loadAOTData:(NSString*)assetsDir {
-  NSLog(@"[shorebird] loading AOT data from assetsDir: %@", assetsDir);
-  FML_LOG(INFO) << "[shorebird][fml] Loading AOT data from assetsDir: " << assetsDir.UTF8String;
+- (void)loadAOTData:(NSString*)elfPath {
   if (!_embedderAPI.RunsAOTCompiledDartCode()) {
     return;
   }
@@ -765,13 +766,9 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   BOOL isDirOut = false;  // required for NSFileManager fileExistsAtPath.
   NSFileManager* fileManager = [NSFileManager defaultManager];
 
-  // This is the location where the test fixture places the snapshot file.
-  // For applications built by Flutter tool, this is in "App.framework".
-  NSString* elfPath = [NSString pathWithComponents:@[ assetsDir, @"app_elf_snapshot.so" ]];
-  FML_LOG(INFO) << "elf path is " << elfPath.UTF8String;
-
   if (![fileManager fileExistsAtPath:elfPath isDirectory:&isDirOut]) {
-    FML_LOG(INFO) << "[shorebird][fml] elfPath does not exist: " << elfPath.UTF8String;
+    FML_LOG(INFO) << "in loadAOTData, elfPath does not exist: "
+        << elfPath.UTF8String;
     return;
   }
 
@@ -782,29 +779,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   auto result = _embedderAPI.CreateAOTData(&source, &_aotData);
   if (result != kSuccess) {
     NSLog(@"Failed to load AOT data from: %@", elfPath);
-  }
-}
-
-- (void)loadAOTDataFromPatch:(NSString*)patchPath {
-  NSLog(@"[shorebird] loading AOT data from patchPath: %@", patchPath);
-  FML_LOG(INFO) << "[shorebird][fml] Loading AOT data from patchPath: " << patchPath.UTF8String;
-  BOOL isDirOut = false;  // required for NSFileManager fileExistsAtPath.
-  NSFileManager* fileManager = [NSFileManager defaultManager];
-
-  if (![fileManager fileExistsAtPath:patchPath isDirectory:&isDirOut]) {
-    NSLog(
-        @"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
-    return;
-  }
-
-  FlutterEngineAOTDataSource source = {};
-  source.type = kFlutterEngineAOTDataSourceTypeElfPath;
-  source.elf_path = [patchPath cStringUsingEncoding:NSUTF8StringEncoding];
-
-  NSLog(@"Creating AOT data from patchPath: %@", patchPath);
-  auto result = _embedderAPI.CreateAOTData(&source, &_aotData);
-  if (result != kSuccess) {
-    NSLog(@"Failed to load AOT data from: %@", patchPath);
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -603,7 +603,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
   // flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
-  // flutterArguments.shorebird_args.app_build_number = 
+  // flutterArguments.shorebird_args.app_build_number =
   //   appBuildNumber.UTF8String;
 
   std::string cache_path =
@@ -831,7 +831,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
 
   if (![fileManager fileExistsAtPath:patchPath isDirectory:&isDirOut]) {
     NSLog(
-      @"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
+        @"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
     return;
   }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -767,8 +767,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   NSFileManager* fileManager = [NSFileManager defaultManager];
 
   if (![fileManager fileExistsAtPath:elfPath isDirectory:&isDirOut]) {
-    FML_LOG(INFO) << "in loadAOTData, elfPath does not exist: "
-        << elfPath.UTF8String;
+    FML_LOG(INFO) << "in loadAOTData, elfPath does not exist: " << elfPath.UTF8String;
     return;
   }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -586,13 +586,12 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-- (BOOL)setUpNonLinkerShorebird:(NSString**)patchPath {
+- (BOOL)configureShorebird:(NSString**)patchPath {
   NSLog(@"[shorebird] setting up non-linker shorebird");
   NSString* bundlePath =
       [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                    URLByAppendingPathComponent:@"App.framework"]] bundlePath];
   bundlePath = [bundlePath stringByAppendingString:@"/App"];
-  // flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
   NSString* assetsPath = _project.assetsPath;
   NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
                                     relativeToURL:[NSURL fileURLWithPath:assetsPath]];
@@ -602,16 +601,8 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   NSString* appVersion =
       [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
-  // flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
-  // flutterArguments.shorebird_args.app_build_number =
-  //   appBuildNumber.UTF8String;
-
   std::string cache_path =
       fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
-  // flutterArguments.shorebird_args.cache_path = cache_path.c_str();
-  // flutterArguments.shorebird_args.shorebird_yaml_contents =
-  //   shorebirdYamlContents.UTF8String;
-
   flutter::ReleaseVersion release_version = {appVersion.UTF8String, appBuildNumber.UTF8String};
   flutter::ShorebirdConfigArgs shorebird_args(cache_path, cache_path, bundlePath.UTF8String,
                                               shorebirdYamlContents.UTF8String, release_version);
@@ -707,46 +698,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       .thread_priority_setter = SetThreadPriority};
   flutterArguments.custom_task_runners = &custom_task_runners;
 
-  NSString* bundlePath =
-      [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
-                                   URLByAppendingPathComponent:@"App.framework"]] bundlePath];
-  bundlePath = [bundlePath stringByAppendingString:@"/App"];
-  flutterArguments.shorebird_args.app_path = bundlePath.UTF8String;
-  NSString* assetsPath = _project.assetsPath;
-  NSURL* shorebirdYamlPath = [NSURL URLWithString:@"shorebird.yaml"
-                                    relativeToURL:[NSURL fileURLWithPath:assetsPath]];
-  NSString* shorebirdYamlContents = [NSString stringWithContentsOfURL:shorebirdYamlPath
-                                                             encoding:NSUTF8StringEncoding
-                                                                error:nil];
-  NSString* appVersion =
-      [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
-  NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
-  flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
-  flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
-
-  std::string cache_path =
-      fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
-  flutterArguments.shorebird_args.cache_path = cache_path.c_str();
-  flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
-
-#if SHOREBIRD_USE_LINKER
-  NSLog(@"[shorebird] Using Shorebird linker");
-  FML_LOG(INFO) << "[shorebird][fml] Using shorebird linker";
-  [self loadAOTData:_project.assetsPath];
-#else
-  NSLog(@"[shorebird] Not using shorebird linker");
-  FML_LOG(INFO) << "[shorebird][fml] Not using shorebird linker";
-  NSString* patchPath;
-  auto configureShorebirdRes = [self setUpNonLinkerShorebird:&patchPath];
-  if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
-    NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
-    [self loadAOTDataFromPatch:patchPath];
-  } else {
-    NSLog(@"[shorebird] failed to configure shorebird");
-    [self loadAOTData:_project.assetsPath];
-  }
-#endif
-
   if (_aotData) {
     flutterArguments.aot_data = _aotData;
   }
@@ -764,6 +715,17 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   };
 
   FlutterRendererConfig rendererConfig = [_renderer createRendererConfig];
+
+  NSString* patchPath;
+  auto configureShorebirdRes = [self configureShorebird:&patchPath];
+  if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
+    NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
+    [self loadAOTDataFromPatch:patchPath];
+  } else {
+    NSLog(@"[shorebird] failed to configure shorebird");
+    [self loadAOTData:_project.assetsPath];
+  }
+
   FlutterEngineResult result = _embedderAPI.Initialize(
       FLUTTER_ENGINE_VERSION, &rendererConfig, &flutterArguments, (__bridge void*)(self), &_engine);
   if (result != kSuccess) {
@@ -839,16 +801,10 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   source.type = kFlutterEngineAOTDataSourceTypeElfPath;
   source.elf_path = [patchPath cStringUsingEncoding:NSUTF8StringEncoding];
 
-  NSLog(@"!!!");
-  NSLog(@"!!!");
   NSLog(@"Creating AOT data from patchPath: %@", patchPath);
-  NSLog(@"!!!");
-  NSLog(@"!!!");
   auto result = _embedderAPI.CreateAOTData(&source, &_aotData);
   if (result != kSuccess) {
     NSLog(@"Failed to load AOT data from: %@", patchPath);
-  } else {
-    NSLog(@"[shorebird] created AOT data");
   }
 }
 

--- a/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
+++ b/shell/platform/darwin/macos/framework/Source/FlutterEngine.mm
@@ -586,7 +586,7 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-- (BOOL)setUpNonLinkerShorebird:(NSString**) patchPath {
+- (BOOL)setUpNonLinkerShorebird:(NSString**)patchPath {
   NSLog(@"[shorebird] setting up non-linker shorebird");
   NSString* bundlePath =
       [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
@@ -603,17 +603,18 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleShortVersionString"];
   NSString* appBuildNumber = [NSBundle.mainBundle objectForInfoDictionaryKey:@"CFBundleVersion"];
   // flutterArguments.shorebird_args.app_version = appVersion.UTF8String;
-  // flutterArguments.shorebird_args.app_build_number = appBuildNumber.UTF8String;
+  // flutterArguments.shorebird_args.app_build_number = 
+  //   appBuildNumber.UTF8String;
 
   std::string cache_path =
       fml::paths::JoinPaths({getenv("HOME"), "Library", "Application Support", "shorebird"});
   // flutterArguments.shorebird_args.cache_path = cache_path.c_str();
-  // flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
+  // flutterArguments.shorebird_args.shorebird_yaml_contents =
+  //   shorebirdYamlContents.UTF8String;
 
   flutter::ReleaseVersion release_version = {appVersion.UTF8String, appBuildNumber.UTF8String};
-  flutter::ShorebirdConfigArgs shorebird_args(
-    cache_path, cache_path, bundlePath.UTF8String,
-    shorebirdYamlContents.UTF8String, release_version);
+  flutter::ShorebirdConfigArgs shorebird_args(cache_path, cache_path, bundlePath.UTF8String,
+                                              shorebirdYamlContents.UTF8String, release_version);
   NSLog(@"[shorebird] calling ConfigureShorebird");
   std::string patch_path;
   auto res = flutter::ConfigureShorebird(shorebird_args, patch_path);
@@ -706,7 +707,6 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
       .thread_priority_setter = SetThreadPriority};
   flutterArguments.custom_task_runners = &custom_task_runners;
 
-
   NSString* bundlePath =
       [[NSBundle bundleWithURL:[NSBundle.mainBundle.privateFrameworksURL
                                    URLByAppendingPathComponent:@"App.framework"]] bundlePath];
@@ -729,23 +729,23 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   flutterArguments.shorebird_args.cache_path = cache_path.c_str();
   flutterArguments.shorebird_args.shorebird_yaml_contents = shorebirdYamlContents.UTF8String;
 
-  #if SHOREBIRD_USE_LINKER
-    NSLog(@"[shorebird] Using Shorebird linker");
-    FML_LOG(INFO) << "[shorebird][fml] Using shorebird linker";
+#if SHOREBIRD_USE_LINKER
+  NSLog(@"[shorebird] Using Shorebird linker");
+  FML_LOG(INFO) << "[shorebird][fml] Using shorebird linker";
+  [self loadAOTData:_project.assetsPath];
+#else
+  NSLog(@"[shorebird] Not using shorebird linker");
+  FML_LOG(INFO) << "[shorebird][fml] Not using shorebird linker";
+  NSString* patchPath;
+  auto configureShorebirdRes = [self setUpNonLinkerShorebird:&patchPath];
+  if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
+    NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
+    [self loadAOTDataFromPatch:patchPath];
+  } else {
+    NSLog(@"[shorebird] failed to configure shorebird");
     [self loadAOTData:_project.assetsPath];
-  #else
-    NSLog(@"[shorebird] Not using shorebird linker");
-    FML_LOG(INFO) << "[shorebird][fml] Not using shorebird linker";
-    NSString* patchPath;
-    auto configureShorebirdRes = [self setUpNonLinkerShorebird:&patchPath];
-    if (configureShorebirdRes && ![patchPath isEqualToString:@""]) {
-      NSLog(@"[shorebird] successfully configured shorebird, loading aot data from %@", patchPath);
-      [self loadAOTDataFromPatch:patchPath];
-    } else {
-      NSLog(@"[shorebird] failed to configure shorebird");
-      [self loadAOTData:_project.assetsPath];
-    }
-  #endif
+  }
+#endif
 
   if (_aotData) {
     flutterArguments.aot_data = _aotData;
@@ -823,14 +823,15 @@ static void SetThreadPriority(FlutterThreadPriority priority) {
   }
 }
 
-- (void)loadAOTDataFromPatch:(NSString *)patchPath {
+- (void)loadAOTDataFromPatch:(NSString*)patchPath {
   NSLog(@"[shorebird] loading AOT data from patchPath: %@", patchPath);
   FML_LOG(INFO) << "[shorebird][fml] Loading AOT data from patchPath: " << patchPath.UTF8String;
   BOOL isDirOut = false;  // required for NSFileManager fileExistsAtPath.
   NSFileManager* fileManager = [NSFileManager defaultManager];
 
   if (![fileManager fileExistsAtPath:patchPath isDirectory:&isDirOut]) {
-    NSLog(@"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
+    NSLog(
+      @"[shorebird] returning early from loadAOTDataFromPatch because patchPath does not exist");
     return;
   }
 

--- a/shell/platform/embedder/BUILD.gn
+++ b/shell/platform/embedder/BUILD.gn
@@ -110,7 +110,6 @@ template("embedder_source_set") {
       "//flutter/lib/ui",
       "//flutter/runtime:libdart",
       "//flutter/shell/common",
-      "//flutter/shell/common/shorebird",
       "//flutter/skia",
       "//flutter/third_party/tonic",
     ]

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -50,7 +50,6 @@ extern const intptr_t kPlatformStrongDillSize;
 #include "flutter/fml/paths.h"
 #include "flutter/fml/trace_event.h"
 #include "flutter/shell/common/rasterizer.h"
-#include "flutter/shell/common/shorebird/shorebird.h"
 #include "flutter/shell/common/switches.h"
 #include "flutter/shell/platform/embedder/embedder.h"
 #include "flutter/shell/platform/embedder/embedder_engine.h"
@@ -2305,22 +2304,6 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
         kInvalidArguments,
         "Could not infer the Flutter project to run from given arguments.");
   }
-
-  // FIXME: This is probably the wrong place to call ConfigureShorebird, as
-  // some platforms (i.e., Windows) need to to swap out the app path before
-  // this point.
-  //
-  // Targets that do not use mixed-mode need to call ConfigureShorebird in their
-  // platform-specific code, prior to calling this function.
-  //
-  // Begin shorebird
-#if SHOREBIRD_USE_LINKER
-  if (args->shorebird_args.shorebird_yaml_contents) {
-    settings.application_library_path.push_back(args->shorebird_args.app_path);
-    flutter::ConfigureShorebird(args->shorebird_args, settings);
-  }
-#endif
-  // End shorebird
 
   // Create the engine but don't launch the shell or run the root isolate.
   auto embedder_engine = std::make_unique<flutter::EmbedderEngine>(

--- a/shell/platform/embedder/embedder.cc
+++ b/shell/platform/embedder/embedder.cc
@@ -2309,8 +2309,12 @@ FlutterEngineResult FlutterEngineInitialize(size_t version,
   // FIXME: This is probably the wrong place to call ConfigureShorebird, as
   // some platforms (i.e., Windows) need to to swap out the app path before
   // this point.
+  //
+  // Targets that do not use mixed-mode need to call ConfigureShorebird in their
+  // platform-specific code, prior to calling this function.
+  //
   // Begin shorebird
-#if FML_OS_MACOSX
+#if SHOREBIRD_USE_LINKER
   if (args->shorebird_args.shorebird_yaml_contents) {
     settings.application_library_path.push_back(args->shorebird_args.app_path);
     flutter::ConfigureShorebird(args->shorebird_args, settings);

--- a/shell/platform/embedder/embedder.h
+++ b/shell/platform/embedder/embedder.h
@@ -2205,42 +2205,6 @@ typedef void (*FlutterLogMessageCallback)(const char* /* tag */,
 typedef struct _FlutterEngineAOTData* FlutterEngineAOTData;
 
 typedef struct {
-  /// The version of the app (e.g., 1.0.0).
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_version;
-
-  /// The build number of the app (e.g., 1).
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_build_number;
-
-  /// The text contents of the shorebird.yaml file bundled with the compiled
-  /// app. Note that this is _not_ the same as the shorebird.yaml that exists in
-  /// the user's project.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* shorebird_yaml_contents;
-
-  /// The path to the directory where Shorebird will store patches and state
-  /// data.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* cache_path;
-
-  /// The path to the executable file. This is a Mach-O executable file on
-  /// macOS.
-  ///
-  /// The string can be collected after the call to `FlutterEngineInitialize`
-  /// returns. The string must be NULL terminated.
-  const char* app_path;
-} ShorebirdFlutterProjectArgs;
-
-typedef struct {
   /// The size of this struct. Must be sizeof(FlutterProjectArgs).
   size_t struct_size;
   /// The path to the Flutter assets directory containing project assets. The
@@ -2539,9 +2503,6 @@ typedef struct {
   /// being registered on the framework side. The callback is invoked from
   /// a task posted to the platform thread.
   FlutterChannelUpdateCallback channel_update_callback;
-
-  /// Data used to initialize Shorebird as part of engine initialization.
-  ShorebirdFlutterProjectArgs shorebird_args;
 } FlutterProjectArgs;
 
 #ifndef FLUTTER_ENGINE_NO_PROTOTYPES


### PR DESCRIPTION
Updates the macOS platform to no longer use mixed mode, but instead swap the AOT snapshot at start time (as is done on Android and Windows). This works because macOS apps don't have the same restriction as iOS apps re: writing executable memory (or rather, developers are easily able to turn off that restriction).