### PR TITLE
Move updater from `third_party` to `flutter/third_party`

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -634,7 +634,7 @@ deps = {
   'src/flutter/third_party/ocmock':
    Var('flutter_git') + '/third_party/ocmock' + '@' +  Var('ocmock_rev'),
 
-   'src/third_party/updater':
+  'src/flutter/third_party/updater':
    Var('updater_git') + '@' + Var('updater_rev'),
 
   'src/flutter/third_party/libjpeg-turbo/src':

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -168,9 +168,7 @@ source_set("common") {
     if (target_cpu == "arm64") {
       libs = [ "//flutter/third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
     } else if (target_cpu == "x64") {
-      libs = [
-        "//flutter/third_party/updater/target/x86_64-apple-darwin/release/libupdater.a",
-      ]
+      libs = [ "//flutter/third_party/updater/target/x86_64-apple-darwin/release/libupdater.a" ]
     }
   }
 

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -166,10 +166,10 @@ source_set("common") {
   # Needed to compile flutter_tester for macOS.
   if (host_os == "mac" && target_os == "mac") {
     if (target_cpu == "arm64") {
-      libs = [ "//third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
+      libs = [ "//flutter/third_party/updater/target/aarch64-apple-darwin/release/libupdater.a" ]
     } else if (target_cpu == "x64") {
       libs = [
-        "//third_party/updater/target/x86_64-apple-darwin/release/libupdater.a",
+        "//flutter/third_party/updater/target/x86_64-apple-darwin/release/libupdater.a",
       ]
     }
   }

--- a/shell/common/BUILD.gn
+++ b/shell/common/BUILD.gn
@@ -177,14 +177,14 @@ source_set("common") {
     if (target_cpu == "x64") {
       libs = [
         "userenv.lib",
-        "//third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
+        "//flutter/third_party/updater/target/x86_64-pc-windows-msvc/release/updater.lib",
       ]
     }
   }
 
   if (host_os == "linux" && target_os == "linux") {
     if (target_cpu == "x64") {
-      libs = [ "//third_party/updater/target/x86_64-unknown-linux-gnu/release/libupdater.a" ]
+      libs = [ "//flutter/third_party/updater/target/x86_64-unknown-linux-gnu/release/libupdater.a" ]
     }
   }
 }

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -183,18 +183,18 @@ source_set("flutter_shell_native_src") {
     "GLESv2",
   ]
   if (target_cpu == "arm") {
-    libs += [ "//third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
+    libs += [ "//flutter/third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
   } else if (target_cpu == "arm64") {
     libs += [
-      "//third_party/updater/target/aarch64-linux-android/release/libupdater.a",
+      "//flutter/third_party/updater/target/aarch64-linux-android/release/libupdater.a",
     ]
   } else if (target_cpu == "x64") {
     libs += [
-      "//third_party/updater/target/x86_64-linux-android/release/libupdater.a",
+      "//flutter/third_party/updater/target/x86_64-linux-android/release/libupdater.a",
     ]
   } else if (target_cpu == "x86") {
     libs += [
-      "//third_party/updater/target/i686-linux-android/release/libupdater.a",
+      "//flutter/third_party/updater/target/i686-linux-android/release/libupdater.a",
     ]
   } else {
     assert(false, "Unsupported target_cpu")

--- a/shell/platform/android/BUILD.gn
+++ b/shell/platform/android/BUILD.gn
@@ -185,17 +185,11 @@ source_set("flutter_shell_native_src") {
   if (target_cpu == "arm") {
     libs += [ "//flutter/third_party/updater/target/armv7-linux-androideabi/release/libupdater.a" ]
   } else if (target_cpu == "arm64") {
-    libs += [
-      "//flutter/third_party/updater/target/aarch64-linux-android/release/libupdater.a",
-    ]
+    libs += [ "//flutter/third_party/updater/target/aarch64-linux-android/release/libupdater.a" ]
   } else if (target_cpu == "x64") {
-    libs += [
-      "//flutter/third_party/updater/target/x86_64-linux-android/release/libupdater.a",
-    ]
+    libs += [ "//flutter/third_party/updater/target/x86_64-linux-android/release/libupdater.a" ]
   } else if (target_cpu == "x86") {
-    libs += [
-      "//flutter/third_party/updater/target/i686-linux-android/release/libupdater.a",
-    ]
+    libs += [ "//flutter/third_party/updater/target/i686-linux-android/release/libupdater.a" ]
   } else {
     assert(false, "Unsupported target_cpu")
   }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -222,11 +222,11 @@ source_set("flutter_framework_source") {
 
   if (target_cpu == "arm64") {
     libs = [
-      "//third_party/updater/target/aarch64-apple-ios/release/libupdater.a",
+      "//flutter/third_party/updater/target/aarch64-apple-ios/release/libupdater.a",
     ]
   } else if (target_cpu == "x64") {
     libs =
-        [ "//third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
+        [ "//flutter/third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
   } else {
     assert(false, "Unsupported target_cpu")
   }

--- a/shell/platform/darwin/ios/BUILD.gn
+++ b/shell/platform/darwin/ios/BUILD.gn
@@ -221,12 +221,9 @@ source_set("flutter_framework_source") {
   ]
 
   if (target_cpu == "arm64") {
-    libs = [
-      "//flutter/third_party/updater/target/aarch64-apple-ios/release/libupdater.a",
-    ]
+    libs = [ "//flutter/third_party/updater/target/aarch64-apple-ios/release/libupdater.a" ]
   } else if (target_cpu == "x64") {
-    libs =
-        [ "//flutter/third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
+    libs = [ "//flutter/third_party/updater/target/x86_64-apple-ios/release/libupdater.a" ]
   } else {
     assert(false, "Unsupported target_cpu")
   }


### PR DESCRIPTION
This brings the updater library in line with all of the other third_party libs, which live in `flutter/third_party`